### PR TITLE
fix: normalize dtypes in flash attn backward launch function

### DIFF
--- a/src/kernel/triton/flashattn.py
+++ b/src/kernel/triton/flashattn.py
@@ -407,11 +407,13 @@ def triton_flash_attn_bwd(
     causal=True,
     sm_scale=None,
 ):
+    # Ensure all inputs share the same dtype — torch.compile/Inductor may promote
+    # some saved tensors (q, k, o, do) to fp32 while v stays in the original dtype.
     q = q.contiguous()
     k = k.contiguous()
     v = v.contiguous()
-    o = o.contiguous()
-    do = do.contiguous()
+    o = o.to(q.dtype).contiguous()
+    do = do.to(q.dtype).contiguous()
 
     batch, n_heads, seq_q, d_head = q.shape
     seq_kv = k.shape[2]


### PR DESCRIPTION
Cast o and do to match q's dtype before launching backward kernels. torch.compile/Inductor may promote some saved tensors to fp32, causing dtype mismatches in tl.dot. Fixing at the Python launch level (not inside kernels) eliminates the identify_mutated_tensors warning with zero performance cost.