### PR TITLE
feat: add dropout sweep experiment for Qwen3 57M

### DIFF
--- a/experiments/dropout/README.md
+++ b/experiments/dropout/README.md
@@ -1,0 +1,45 @@
+# Dropout Sweep
+
+Sweep dropout rate on Qwen3 57M to measure its effect on pretrain loss.
+
+## Hypothesis
+
+Higher dropout hurts pretraining by randomly zeroing activations, increasing noise and slowing convergence. Very high dropout (≥0.5) should significantly degrade loss. Low dropout (0.01–0.05) may act as mild regularization with negligible cost, while 0.0 (no dropout) should serve as the best baseline for a compute-limited pretraining run.
+
+## Setup
+
+| Config | Dropout |
+|---|---|
+| qwen3_57m_drop0.0 | 0.0 |
+| qwen3_57m_drop0.01 | 0.01 |
+| qwen3_57m_drop0.02 | 0.02 |
+| qwen3_57m_drop0.05 | 0.05 |
+| qwen3_57m_drop0.1 | 0.1 |
+| qwen3_57m_drop0.2 | 0.2 |
+| qwen3_57m_drop0.5 | 0.5 |
+| qwen3_57m_drop0.9 | 0.9 |
+| qwen3_57m_drop0.95 | 0.95 |
+| qwen3_57m_drop0.99 | 0.99 |
+
+All runs share: Qwen3 57M (d_model=512, layers=8, heads=8, kv_heads=4), seq_len=1024, batch_size=4, grad_accum=8 (effective batch=32), lr=1e-4, 50K steps, cosine schedule with 1K warmup steps, bf16, OpenWebText.
+
+## Run
+
+```bash
+nohup bash experiments/dropout/run.sh > logs/dropout.log 2>&1 &
+```
+
+## Results
+
+| Dropout | Final Val Loss |
+|---|---|
+| 0.0 | |
+| 0.01 | |
+| 0.02 | |
+| 0.05 | |
+| 0.1 | |
+| 0.2 | |
+| 0.5 | |
+| 0.9 | |
+| 0.95 | |
+| 0.99 | |

--- a/experiments/dropout/qwen3_57m_drop0.0.yaml
+++ b/experiments/dropout/qwen3_57m_drop0.0.yaml
@@ -1,0 +1,48 @@
+max_seq_len: 1024
+
+model:
+  arch: "qwen3"
+  n_layers: 8
+  n_heads: 8
+  n_kv_heads: 4
+  d_model: 512
+  vocab_size: 50257
+  dropout: 0.0
+  rope_theta: 10000.0
+  qk_norm: true
+
+data:
+  dataset: "openwebtext"
+  tokenizer_path: "tokenizers/custom_bpe_50k"
+  data_dir: "data/"
+  val_split: 0.01
+  num_workers: 4
+
+training:
+  batch_size: 4
+  gradient_accumulation_steps: 8
+  max_steps: 50000
+  mixed_precision: "bf16"
+  backend: "torch"
+  activation_checkpointing: false
+  grad_clip: 1.0
+  checkpoint_dir: "checkpoints/dropout/qwen3_drop0.0/"
+  checkpoint_every: 5000
+  eval_every: 1000
+  eval_steps: 200
+
+optimizer:
+  name: "adamw"
+  lr: 1e-4
+  weight_decay: 0.1
+  betas: [0.9, 0.95]
+
+scheduler:
+  name: "cosine"
+  warmup_steps: 1000
+  min_lr: 1e-5
+
+logging:
+  wandb_project: "pretrain-dropout"
+  wandb_run_name: "qwen3-57m-drop0.0"
+  log_every: 10

--- a/experiments/dropout/qwen3_57m_drop0.01.yaml
+++ b/experiments/dropout/qwen3_57m_drop0.01.yaml
@@ -1,0 +1,48 @@
+max_seq_len: 1024
+
+model:
+  arch: "qwen3"
+  n_layers: 8
+  n_heads: 8
+  n_kv_heads: 4
+  d_model: 512
+  vocab_size: 50257
+  dropout: 0.01
+  rope_theta: 10000.0
+  qk_norm: true
+
+data:
+  dataset: "openwebtext"
+  tokenizer_path: "tokenizers/custom_bpe_50k"
+  data_dir: "data/"
+  val_split: 0.01
+  num_workers: 4
+
+training:
+  batch_size: 4
+  gradient_accumulation_steps: 8
+  max_steps: 50000
+  mixed_precision: "bf16"
+  backend: "torch"
+  activation_checkpointing: false
+  grad_clip: 1.0
+  checkpoint_dir: "checkpoints/dropout/qwen3_drop0.01/"
+  checkpoint_every: 5000
+  eval_every: 1000
+  eval_steps: 200
+
+optimizer:
+  name: "adamw"
+  lr: 1e-4
+  weight_decay: 0.1
+  betas: [0.9, 0.95]
+
+scheduler:
+  name: "cosine"
+  warmup_steps: 1000
+  min_lr: 1e-5
+
+logging:
+  wandb_project: "pretrain-dropout"
+  wandb_run_name: "qwen3-57m-drop0.01"
+  log_every: 10

--- a/experiments/dropout/qwen3_57m_drop0.02.yaml
+++ b/experiments/dropout/qwen3_57m_drop0.02.yaml
@@ -1,0 +1,48 @@
+max_seq_len: 1024
+
+model:
+  arch: "qwen3"
+  n_layers: 8
+  n_heads: 8
+  n_kv_heads: 4
+  d_model: 512
+  vocab_size: 50257
+  dropout: 0.02
+  rope_theta: 10000.0
+  qk_norm: true
+
+data:
+  dataset: "openwebtext"
+  tokenizer_path: "tokenizers/custom_bpe_50k"
+  data_dir: "data/"
+  val_split: 0.01
+  num_workers: 4
+
+training:
+  batch_size: 4
+  gradient_accumulation_steps: 8
+  max_steps: 50000
+  mixed_precision: "bf16"
+  backend: "torch"
+  activation_checkpointing: false
+  grad_clip: 1.0
+  checkpoint_dir: "checkpoints/dropout/qwen3_drop0.02/"
+  checkpoint_every: 5000
+  eval_every: 1000
+  eval_steps: 200
+
+optimizer:
+  name: "adamw"
+  lr: 1e-4
+  weight_decay: 0.1
+  betas: [0.9, 0.95]
+
+scheduler:
+  name: "cosine"
+  warmup_steps: 1000
+  min_lr: 1e-5
+
+logging:
+  wandb_project: "pretrain-dropout"
+  wandb_run_name: "qwen3-57m-drop0.02"
+  log_every: 10

--- a/experiments/dropout/qwen3_57m_drop0.05.yaml
+++ b/experiments/dropout/qwen3_57m_drop0.05.yaml
@@ -1,0 +1,48 @@
+max_seq_len: 1024
+
+model:
+  arch: "qwen3"
+  n_layers: 8
+  n_heads: 8
+  n_kv_heads: 4
+  d_model: 512
+  vocab_size: 50257
+  dropout: 0.05
+  rope_theta: 10000.0
+  qk_norm: true
+
+data:
+  dataset: "openwebtext"
+  tokenizer_path: "tokenizers/custom_bpe_50k"
+  data_dir: "data/"
+  val_split: 0.01
+  num_workers: 4
+
+training:
+  batch_size: 4
+  gradient_accumulation_steps: 8
+  max_steps: 50000
+  mixed_precision: "bf16"
+  backend: "torch"
+  activation_checkpointing: false
+  grad_clip: 1.0
+  checkpoint_dir: "checkpoints/dropout/qwen3_drop0.05/"
+  checkpoint_every: 5000
+  eval_every: 1000
+  eval_steps: 200
+
+optimizer:
+  name: "adamw"
+  lr: 1e-4
+  weight_decay: 0.1
+  betas: [0.9, 0.95]
+
+scheduler:
+  name: "cosine"
+  warmup_steps: 1000
+  min_lr: 1e-5
+
+logging:
+  wandb_project: "pretrain-dropout"
+  wandb_run_name: "qwen3-57m-drop0.05"
+  log_every: 10

--- a/experiments/dropout/qwen3_57m_drop0.1.yaml
+++ b/experiments/dropout/qwen3_57m_drop0.1.yaml
@@ -1,0 +1,48 @@
+max_seq_len: 1024
+
+model:
+  arch: "qwen3"
+  n_layers: 8
+  n_heads: 8
+  n_kv_heads: 4
+  d_model: 512
+  vocab_size: 50257
+  dropout: 0.1
+  rope_theta: 10000.0
+  qk_norm: true
+
+data:
+  dataset: "openwebtext"
+  tokenizer_path: "tokenizers/custom_bpe_50k"
+  data_dir: "data/"
+  val_split: 0.01
+  num_workers: 4
+
+training:
+  batch_size: 4
+  gradient_accumulation_steps: 8
+  max_steps: 50000
+  mixed_precision: "bf16"
+  backend: "torch"
+  activation_checkpointing: false
+  grad_clip: 1.0
+  checkpoint_dir: "checkpoints/dropout/qwen3_drop0.1/"
+  checkpoint_every: 5000
+  eval_every: 1000
+  eval_steps: 200
+
+optimizer:
+  name: "adamw"
+  lr: 1e-4
+  weight_decay: 0.1
+  betas: [0.9, 0.95]
+
+scheduler:
+  name: "cosine"
+  warmup_steps: 1000
+  min_lr: 1e-5
+
+logging:
+  wandb_project: "pretrain-dropout"
+  wandb_run_name: "qwen3-57m-drop0.1"
+  log_every: 10

--- a/experiments/dropout/qwen3_57m_drop0.2.yaml
+++ b/experiments/dropout/qwen3_57m_drop0.2.yaml
@@ -1,0 +1,48 @@
+max_seq_len: 1024
+
+model:
+  arch: "qwen3"
+  n_layers: 8
+  n_heads: 8
+  n_kv_heads: 4
+  d_model: 512
+  vocab_size: 50257
+  dropout: 0.2
+  rope_theta: 10000.0
+  qk_norm: true
+
+data:
+  dataset: "openwebtext"
+  tokenizer_path: "tokenizers/custom_bpe_50k"
+  data_dir: "data/"
+  val_split: 0.01
+  num_workers: 4
+
+training:
+  batch_size: 4
+  gradient_accumulation_steps: 8
+  max_steps: 50000
+  mixed_precision: "bf16"
+  backend: "torch"
+  activation_checkpointing: false
+  grad_clip: 1.0
+  checkpoint_dir: "checkpoints/dropout/qwen3_drop0.2/"
+  checkpoint_every: 5000
+  eval_every: 1000
+  eval_steps: 200
+
+optimizer:
+  name: "adamw"
+  lr: 1e-4
+  weight_decay: 0.1
+  betas: [0.9, 0.95]
+
+scheduler:
+  name: "cosine"
+  warmup_steps: 1000
+  min_lr: 1e-5
+
+logging:
+  wandb_project: "pretrain-dropout"
+  wandb_run_name: "qwen3-57m-drop0.2"
+  log_every: 10

--- a/experiments/dropout/qwen3_57m_drop0.5.yaml
+++ b/experiments/dropout/qwen3_57m_drop0.5.yaml
@@ -1,0 +1,48 @@
+max_seq_len: 1024
+
+model:
+  arch: "qwen3"
+  n_layers: 8
+  n_heads: 8
+  n_kv_heads: 4
+  d_model: 512
+  vocab_size: 50257
+  dropout: 0.5
+  rope_theta: 10000.0
+  qk_norm: true
+
+data:
+  dataset: "openwebtext"
+  tokenizer_path: "tokenizers/custom_bpe_50k"
+  data_dir: "data/"
+  val_split: 0.01
+  num_workers: 4
+
+training:
+  batch_size: 4
+  gradient_accumulation_steps: 8
+  max_steps: 50000
+  mixed_precision: "bf16"
+  backend: "torch"
+  activation_checkpointing: false
+  grad_clip: 1.0
+  checkpoint_dir: "checkpoints/dropout/qwen3_drop0.5/"
+  checkpoint_every: 5000
+  eval_every: 1000
+  eval_steps: 200
+
+optimizer:
+  name: "adamw"
+  lr: 1e-4
+  weight_decay: 0.1
+  betas: [0.9, 0.95]
+
+scheduler:
+  name: "cosine"
+  warmup_steps: 1000
+  min_lr: 1e-5
+
+logging:
+  wandb_project: "pretrain-dropout"
+  wandb_run_name: "qwen3-57m-drop0.5"
+  log_every: 10

--- a/experiments/dropout/qwen3_57m_drop0.9.yaml
+++ b/experiments/dropout/qwen3_57m_drop0.9.yaml
@@ -1,0 +1,48 @@
+max_seq_len: 1024
+
+model:
+  arch: "qwen3"
+  n_layers: 8
+  n_heads: 8
+  n_kv_heads: 4
+  d_model: 512
+  vocab_size: 50257
+  dropout: 0.9
+  rope_theta: 10000.0
+  qk_norm: true
+
+data:
+  dataset: "openwebtext"
+  tokenizer_path: "tokenizers/custom_bpe_50k"
+  data_dir: "data/"
+  val_split: 0.01
+  num_workers: 4
+
+training:
+  batch_size: 4
+  gradient_accumulation_steps: 8
+  max_steps: 50000
+  mixed_precision: "bf16"
+  backend: "torch"
+  activation_checkpointing: false
+  grad_clip: 1.0
+  checkpoint_dir: "checkpoints/dropout/qwen3_drop0.9/"
+  checkpoint_every: 5000
+  eval_every: 1000
+  eval_steps: 200
+
+optimizer:
+  name: "adamw"
+  lr: 1e-4
+  weight_decay: 0.1
+  betas: [0.9, 0.95]
+
+scheduler:
+  name: "cosine"
+  warmup_steps: 1000
+  min_lr: 1e-5
+
+logging:
+  wandb_project: "pretrain-dropout"
+  wandb_run_name: "qwen3-57m-drop0.9"
+  log_every: 10

--- a/experiments/dropout/qwen3_57m_drop0.95.yaml
+++ b/experiments/dropout/qwen3_57m_drop0.95.yaml
@@ -1,0 +1,48 @@
+max_seq_len: 1024
+
+model:
+  arch: "qwen3"
+  n_layers: 8
+  n_heads: 8
+  n_kv_heads: 4
+  d_model: 512
+  vocab_size: 50257
+  dropout: 0.95
+  rope_theta: 10000.0
+  qk_norm: true
+
+data:
+  dataset: "openwebtext"
+  tokenizer_path: "tokenizers/custom_bpe_50k"
+  data_dir: "data/"
+  val_split: 0.01
+  num_workers: 4
+
+training:
+  batch_size: 4
+  gradient_accumulation_steps: 8
+  max_steps: 50000
+  mixed_precision: "bf16"
+  backend: "torch"
+  activation_checkpointing: false
+  grad_clip: 1.0
+  checkpoint_dir: "checkpoints/dropout/qwen3_drop0.95/"
+  checkpoint_every: 5000
+  eval_every: 1000
+  eval_steps: 200
+
+optimizer:
+  name: "adamw"
+  lr: 1e-4
+  weight_decay: 0.1
+  betas: [0.9, 0.95]
+
+scheduler:
+  name: "cosine"
+  warmup_steps: 1000
+  min_lr: 1e-5
+
+logging:
+  wandb_project: "pretrain-dropout"
+  wandb_run_name: "qwen3-57m-drop0.95"
+  log_every: 10

--- a/experiments/dropout/qwen3_57m_drop0.99.yaml
+++ b/experiments/dropout/qwen3_57m_drop0.99.yaml
@@ -1,0 +1,48 @@
+max_seq_len: 1024
+
+model:
+  arch: "qwen3"
+  n_layers: 8
+  n_heads: 8
+  n_kv_heads: 4
+  d_model: 512
+  vocab_size: 50257
+  dropout: 0.99
+  rope_theta: 10000.0
+  qk_norm: true
+
+data:
+  dataset: "openwebtext"
+  tokenizer_path: "tokenizers/custom_bpe_50k"
+  data_dir: "data/"
+  val_split: 0.01
+  num_workers: 4
+
+training:
+  batch_size: 4
+  gradient_accumulation_steps: 8
+  max_steps: 50000
+  mixed_precision: "bf16"
+  backend: "torch"
+  activation_checkpointing: false
+  grad_clip: 1.0
+  checkpoint_dir: "checkpoints/dropout/qwen3_drop0.99/"
+  checkpoint_every: 5000
+  eval_every: 1000
+  eval_steps: 200
+
+optimizer:
+  name: "adamw"
+  lr: 1e-4
+  weight_decay: 0.1
+  betas: [0.9, 0.95]
+
+scheduler:
+  name: "cosine"
+  warmup_steps: 1000
+  min_lr: 1e-5
+
+logging:
+  wandb_project: "pretrain-dropout"
+  wandb_run_name: "qwen3-57m-drop0.99"
+  log_every: 10

--- a/experiments/dropout/run.sh
+++ b/experiments/dropout/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Run all dropout experiments sequentially (smallest to largest)
+# Usage: nohup bash experiments/dropout/run.sh > logs/dropout.log 2>&1 &
+
+set -e
+cd "$(dirname "$0")/../.."
+
+for config in qwen3_57m_drop0.0 qwen3_57m_drop0.01 qwen3_57m_drop0.02 qwen3_57m_drop0.05 qwen3_57m_drop0.1 qwen3_57m_drop0.2 qwen3_57m_drop0.5 qwen3_57m_drop0.9 qwen3_57m_drop0.95 qwen3_57m_drop0.99; do
+    echo "=== ${config} ==="
+    echo "Started at: $(date)"
+    uv run python scripts/train.py --config "experiments/dropout/${config}.yaml"
+    echo "Finished at: $(date)"
+    echo ""
+done
+
+echo "=== All dropout runs complete ==="


### PR DESCRIPTION
Sweeps dropout in [0.0, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 0.9, 0.95, 0.99] to measure effect on pretrain loss.