### PR TITLE
fix: re-enable use_deterministic_algorithms for padded vocab cross en…

### DIFF
--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -34,12 +34,8 @@ class Trainer:
 
         # Prefer deterministic CUDA algorithms
         if config.training.use_deterministic_algo:
-            # cannot achieve true deterministic due to torch's SDPA
             os.environ['CUBLAS_WORKSPACE_CONFIG'] = ':4096:8'
-            # TODO: Due to torch cross entropy kernel bug
-            # It cannot handle padded vocab when use deterministic algo
-            # Error is causing OOB index, disable for now until fix
-            # torch.use_deterministic_algorithms(True, warn_only=True)
+            torch.use_deterministic_algorithms(True, warn_only=True)
 
         # Seed for reproducibility
         self._seed(config.training.seed)


### PR DESCRIPTION
…tropy

The OOB index error in F.cross_entropy with padded vocab under torch.use_deterministic_algorithms was a PyTorch bug fixed in 2.10. Uncomment the call and drop the stale TODO/workaround comments.