### PR TITLE
[feat] add all-e4m3 grad-format arm to fp8_muon sweep

### DIFF
--- a/experiments/fp8_muon/README.md
+++ b/experiments/fp8_muon/README.md
@@ -22,10 +22,14 @@ All four configs are identical except `optimizer.name` (+ Muon-only hyperparams)
 
 | Config | Optimizer | Precision | Grad fmt | LR | min_lr | WD | Eff. batch | Approx params |
 |---|---|---|---|---|---|---|---|---|
+| qwen3_51m_bf16_adamw        | AdamW | bf16           | —     | 5e-4 | 5e-5 | 0.1 | 256 | ~51M |
+| qwen3_51m_bf16_muon         | Muon  | bf16           | —     | 5e-4 | 5e-5 | 0.1 | 256 | ~51M |
 | qwen3_51m_fp8_std_adamw     | AdamW | fp8 tensorwise | e5m2  | 5e-4 | 5e-5 | 0.1 | 256 | ~51M |
 | qwen3_51m_fp8_std_muon      | Muon  | fp8 tensorwise | e5m2  | 5e-4 | 5e-5 | 0.1 | 256 | ~51M |
 | qwen3_51m_fp8_alle4m3_adamw | AdamW | fp8 tensorwise | e4m3  | 5e-4 | 5e-5 | 0.1 | 256 | ~51M |
 | qwen3_51m_fp8_alle4m3_muon  | Muon  | fp8 tensorwise | e4m3  | 5e-4 | 5e-5 | 0.1 | 256 | ~51M |
+
+The bf16 pair is the full-precision reference (`quant.enabled: false`): it anchors the bf16 Muon−AdamW gap this experiment asks about, so the FP8 gaps can be read as degradation relative to it rather than against the external `experiments/muon_optm/` run.
 
 - Model: d_model=512, 8 layers, gqa 8/4, qk_norm, intermediate_size=1536, rope θ=10000.
 - FP8 block: explicit `dtype` map (std: weight/act `fp8_e4m3` + grad `fp8_e5m2`; alle4m3: all operands `fp8_e4m3`), `scaling.granularity: tensorwise`, `exclude: [lm_head]`. Only eligible `nn.Linear` GEMM operands are cast to FP8 on the fly; RoPE, RMSNorm, qk_norm, attention, SwiGLU, residuals, embeddings, lm_head, cross-entropy, and optimizer state stay bf16/fp32. hp master weights preserved. (cuBLAS rejects e5m2×e5m2, so e4m3 weight/act is required either way.)
@@ -37,7 +41,7 @@ Hardware requirement: SM 8.9+ (Ada/Hopper/Blackwell). On the dev box (RTX PRO 60
 
 ## Run
 
-The script sweeps `{std, alle4m3} × {adamw, muon}` in order.
+The script runs the bf16 baselines first, then sweeps `{std, alle4m3} × {adamw, muon}`.
 
 ```bash
 nohup bash experiments/fp8_muon/run.sh > logs/fp8_muon_51m.log 2>&1 &
@@ -45,16 +49,18 @@ nohup bash experiments/fp8_muon/run.sh > logs/fp8_muon_51m.log 2>&1 &
 
 ## Results
 
-| Model | Optimizer | Grad fmt | Final Val Loss | Val BPB | Δ vs AdamW |
+| Model | Optimizer | Precision / Grad fmt | Final Val Loss | Val BPB | Δ vs AdamW |
 |---|---|---|---|---|---|
-| 51M | AdamW | e5m2 (std)     | TBD | TBD | — |
-| 51M | Muon  | e5m2 (std)     | TBD | TBD | TBD |
-| 51M | AdamW | e4m3 (alle4m3) | TBD | TBD | — |
-| 51M | Muon  | e4m3 (alle4m3) | TBD | TBD | TBD |
+| 51M | AdamW | bf16           | TBD | TBD | — |
+| 51M | Muon  | bf16           | TBD | TBD | TBD |
+| 51M | AdamW | fp8 e5m2 (std)     | TBD | TBD | — |
+| 51M | Muon  | fp8 e5m2 (std)     | TBD | TBD | TBD |
+| 51M | AdamW | fp8 e4m3 (alle4m3) | TBD | TBD | — |
+| 51M | Muon  | fp8 e4m3 (alle4m3) | TBD | TBD | TBD |
 
 ## Notes
 
-- Compare the FP8 Muon−AdamW gap here against the bf16 Muon−AdamW gap in `experiments/muon_optm/` — a preserved gap supports outcome (1), a shrunk gap supports (2).
+- Compare the FP8 Muon−AdamW gap here against the in-experiment bf16 baseline pair — a preserved gap supports outcome (1), a shrunk gap supports (2). (`experiments/muon_optm/` is a looser external reference.)
 - `optim/momentum_norm` and `optim/variance_norm` in W&B reflect only the AdamW-routed params (Muon's `momentum_buffer` is not aggregated by `metric_utils`).
 - tensorwise is the most aggressive recipe; if Muon's edge collapses here, rerun with `rowwise` / `rowwise_with_gw_hp` (see `experiments/fp8_granularity/`) to see whether tighter scaling restores it.
 - If turnaround matters, compare the 5K/10K-step intermediate eval losses before committing all runs to 50K.

--- a/experiments/fp8_muon/README.md
+++ b/experiments/fp8_muon/README.md
@@ -1,6 +1,12 @@
 # Muon vs AdamW under FP8
 
-Does Muon's per-step advantage over AdamW survive FP8 quantization? Compare the two optimizers at Qwen3-51M with FP8 **tensorwise** GEMMs (in-house `src/quant/`, cuBLASLt via `torch._scaled_mm`), holding everything except `optimizer.name` fixed.
+Does Muon's per-step advantage over AdamW survive FP8 quantization, and does that depend on the grad format? Sweep two optimizers × two FP8 dtype assignments at Qwen3-51M with FP8 **tensorwise** GEMMs (in-house `src/quant/`, cuBLASLt via `torch._scaled_mm`), holding everything else fixed.
+
+The two dtype assignments differ only in the gradient GEMM operands:
+- **std** — weight/act `fp8_e4m3`, grad (`input_grad`/`weight_grad`) `fp8_e5m2`. The standard mixed-format recipe: e5m2 trades mantissa for exponent range on the wider-dynamic-range gradients.
+- **alle4m3** — every operand (weight/act/grad) `fp8_e4m3`. Keeps grad mantissa precision at the cost of dynamic range; stresses whether the extra range in e5m2 actually matters here.
+
+Both are written as explicit `dtype` maps (no named `dtype_recipe`) so the grad-format axis is visible in the config.
 
 ## Hypothesis
 
@@ -12,15 +18,17 @@ Muon orthogonalizes each 2D weight's momentum via Newton–Schulz, equalizing th
 
 ## Setup
 
-Both configs are identical except `optimizer.name` (and the Muon-only hyperparams). Muon uses the hybrid `MuonAdamWOptimizer`: 2D hidden weights → Muon, everything else (embeddings, `lm_head`, RMSNorm scales) → AdamW. `adjust_lr_fn=match_rms_adamw` matches Muon's update RMS to AdamW so it reuses the AdamW-tuned `lr`/`wd` directly.
+All four configs are identical except `optimizer.name` (+ Muon-only hyperparams) and the grad `dtype` (std vs alle4m3). Muon uses the hybrid `MuonAdamWOptimizer`: 2D hidden weights → Muon, everything else (embeddings, `lm_head`, RMSNorm scales) → AdamW. `adjust_lr_fn=match_rms_adamw` matches Muon's update RMS to AdamW so it reuses the AdamW-tuned `lr`/`wd` directly.
 
-| Config | Optimizer | Precision | Recipe | LR | min_lr | WD | Eff. batch | Approx params |
+| Config | Optimizer | Precision | Grad fmt | LR | min_lr | WD | Eff. batch | Approx params |
 |---|---|---|---|---|---|---|---|---|
-| qwen3_51m_fp8_adamw | AdamW | fp8 | tensorwise | 5e-4 | 5e-5 | 0.1 | 256 | ~51M |
-| qwen3_51m_fp8_muon  | Muon  | fp8 | tensorwise | 5e-4 | 5e-5 | 0.1 | 256 | ~51M |
+| qwen3_51m_fp8_std_adamw     | AdamW | fp8 tensorwise | e5m2  | 5e-4 | 5e-5 | 0.1 | 256 | ~51M |
+| qwen3_51m_fp8_std_muon      | Muon  | fp8 tensorwise | e5m2  | 5e-4 | 5e-5 | 0.1 | 256 | ~51M |
+| qwen3_51m_fp8_alle4m3_adamw | AdamW | fp8 tensorwise | e4m3  | 5e-4 | 5e-5 | 0.1 | 256 | ~51M |
+| qwen3_51m_fp8_alle4m3_muon  | Muon  | fp8 tensorwise | e4m3  | 5e-4 | 5e-5 | 0.1 | 256 | ~51M |
 
 - Model: d_model=512, 8 layers, gqa 8/4, qk_norm, intermediate_size=1536, rope θ=10000.
-- FP8 block: `dtype_recipe: fp8` (weight/act `fp8_e4m3`, grad `fp8_e5m2`), `scaling.granularity: tensorwise`, `exclude: [lm_head]`. Only eligible `nn.Linear` GEMM operands are cast to FP8 on the fly; RoPE, RMSNorm, qk_norm, attention, SwiGLU, residuals, embeddings, lm_head, cross-entropy, and optimizer state stay bf16/fp32. hp master weights preserved.
+- FP8 block: explicit `dtype` map (std: weight/act `fp8_e4m3` + grad `fp8_e5m2`; alle4m3: all operands `fp8_e4m3`), `scaling.granularity: tensorwise`, `exclude: [lm_head]`. Only eligible `nn.Linear` GEMM operands are cast to FP8 on the fly; RoPE, RMSNorm, qk_norm, attention, SwiGLU, residuals, embeddings, lm_head, cross-entropy, and optimizer state stay bf16/fp32. hp master weights preserved. (cuBLAS rejects e5m2×e5m2, so e4m3 weight/act is required either way.)
 - Muon hyperparams at defaults: `momentum=0.95`, `nesterov=true`, `ns_steps=5`, shared `eps=1e-8`.
 - All runs: seq_len=1024, batch=16, grad_accum=16 (eff. batch=256, ~262K tok/step), 50K steps (~13B tokens), bf16 mixed precision, cosine schedule with 1500 warmup, seed=42, OpenWebText.
 - `eval_every=100`, `eval_steps=100`, `checkpoint_every=5000`, `log_optimizer_svd_metrics: true`.
@@ -29,7 +37,7 @@ Hardware requirement: SM 8.9+ (Ada/Hopper/Blackwell). On the dev box (RTX PRO 60
 
 ## Run
 
-The script runs the AdamW config followed by the Muon config.
+The script sweeps `{std, alle4m3} × {adamw, muon}` in order.
 
 ```bash
 nohup bash experiments/fp8_muon/run.sh > logs/fp8_muon_51m.log 2>&1 &
@@ -37,14 +45,17 @@ nohup bash experiments/fp8_muon/run.sh > logs/fp8_muon_51m.log 2>&1 &
 
 ## Results
 
-| Model | Optimizer | Precision | Final Val Loss | Val BPB | Δ vs AdamW |
+| Model | Optimizer | Grad fmt | Final Val Loss | Val BPB | Δ vs AdamW |
 |---|---|---|---|---|---|
-| 51M | AdamW | fp8 tensorwise | TBD | TBD | — |
-| 51M | Muon  | fp8 tensorwise | TBD | TBD | TBD |
+| 51M | AdamW | e5m2 (std)     | TBD | TBD | — |
+| 51M | Muon  | e5m2 (std)     | TBD | TBD | TBD |
+| 51M | AdamW | e4m3 (alle4m3) | TBD | TBD | — |
+| 51M | Muon  | e4m3 (alle4m3) | TBD | TBD | TBD |
 
 ## Notes
 
 - Compare the FP8 Muon−AdamW gap here against the bf16 Muon−AdamW gap in `experiments/muon_optm/` — a preserved gap supports outcome (1), a shrunk gap supports (2).
 - `optim/momentum_norm` and `optim/variance_norm` in W&B reflect only the AdamW-routed params (Muon's `momentum_buffer` is not aggregated by `metric_utils`).
 - tensorwise is the most aggressive recipe; if Muon's edge collapses here, rerun with `rowwise` / `rowwise_with_gw_hp` (see `experiments/fp8_granularity/`) to see whether tighter scaling restores it.
-- If turnaround matters, compare the 5K/10K-step intermediate eval losses before committing both runs to 50K.
+- If turnaround matters, compare the 5K/10K-step intermediate eval losses before committing all runs to 50K.
+- std vs alle4m3 isolates the grad format: if alle4m3 degrades (or diverges), e5m2's extra dynamic range on gradients is load-bearing at tensorwise scaling; if it matches std, the grad mantissa precision wins the trade. Watch whether the effect differs between AdamW and Muon.

--- a/experiments/fp8_muon/qwen3_51m_bf16_adamw.yaml
+++ b/experiments/fp8_muon/qwen3_51m_bf16_adamw.yaml
@@ -1,0 +1,62 @@
+max_seq_len: 1024
+
+model:
+  d_model: 512
+  n_layers: 8
+  vocab_size: 50257
+  attn:
+  - attn_cls: gqa
+    attn_kwargs:
+      n_heads: 8
+      n_kv_heads: 4
+      qk_norm: true
+      dropout: 0.0
+  mlp:
+  - mlp_cls: dense
+    mlp_kwargs:
+      intermediate_size: 1536
+      dropout: 0.0
+  norm_cls: rmsnorm
+  pos_emb_cls: rope
+  pos_emb_kwargs:
+    rope_theta: 10000.0
+  dropout_embd: 0.0
+
+data:
+  dataset: openwebtext
+  tokenizer_path: tokenizers/custom_bpe_50k
+  data_dir: data/
+  val_split: 0.01
+  num_workers: 4
+
+training:
+  batch_size: 16
+  gradient_accumulation_steps: 16
+  max_steps: 50000
+  mixed_precision: bf16
+  seed: 42
+  quant:
+    enabled: false
+  grad_clip: 1.0
+  checkpoint_dir: checkpoints/fp8_muon/qwen3_51m_bf16_adamw/
+  checkpoint_every: 5000
+  eval_every: 100
+  eval_steps: 100
+
+optimizer:
+  name: adamw
+  lr: 5e-4
+  weight_decay: 0.1
+  betas:
+  - 0.9
+  - 0.95
+
+scheduler:
+  name: cosine
+  warmup_steps: 1500
+  min_lr: 5e-5
+
+logging:
+  wandb_project: pretrain-fp8-muon
+  wandb_run_name: qwen3-51m-bf16-adamw
+  log_every: 10

--- a/experiments/fp8_muon/qwen3_51m_bf16_muon.yaml
+++ b/experiments/fp8_muon/qwen3_51m_bf16_muon.yaml
@@ -1,0 +1,65 @@
+max_seq_len: 1024
+
+model:
+  d_model: 512
+  n_layers: 8
+  vocab_size: 50257
+  attn:
+  - attn_cls: gqa
+    attn_kwargs:
+      n_heads: 8
+      n_kv_heads: 4
+      qk_norm: true
+      dropout: 0.0
+  mlp:
+  - mlp_cls: dense
+    mlp_kwargs:
+      intermediate_size: 1536
+      dropout: 0.0
+  norm_cls: rmsnorm
+  pos_emb_cls: rope
+  pos_emb_kwargs:
+    rope_theta: 10000.0
+  dropout_embd: 0.0
+
+data:
+  dataset: openwebtext
+  tokenizer_path: tokenizers/custom_bpe_50k
+  data_dir: data/
+  val_split: 0.01
+  num_workers: 4
+
+training:
+  batch_size: 16
+  gradient_accumulation_steps: 16
+  max_steps: 50000
+  mixed_precision: bf16
+  seed: 42
+  quant:
+    enabled: false
+  grad_clip: 1.0
+  checkpoint_dir: checkpoints/fp8_muon/qwen3_51m_bf16_muon/
+  checkpoint_every: 5000
+  eval_every: 100
+  eval_steps: 100
+
+optimizer:
+  name: muon
+  lr: 5e-4
+  weight_decay: 0.1
+  betas:
+  - 0.9
+  - 0.95
+  muon_momentum: 0.95
+  muon_nesterov: true
+  muon_adjust_lr_fn: match_rms_adamw
+
+scheduler:
+  name: cosine
+  warmup_steps: 1500
+  min_lr: 5e-5
+
+logging:
+  wandb_project: pretrain-fp8-muon
+  wandb_run_name: qwen3-51m-bf16-muon
+  log_every: 10

--- a/experiments/fp8_muon/qwen3_51m_fp8_alle4m3_adamw.yaml
+++ b/experiments/fp8_muon/qwen3_51m_fp8_alle4m3_adamw.yaml
@@ -1,0 +1,70 @@
+max_seq_len: 1024
+
+model:
+  d_model: 512
+  n_layers: 8
+  vocab_size: 50257
+  attn:
+  - attn_cls: gqa
+    attn_kwargs:
+      n_heads: 8
+      n_kv_heads: 4
+      qk_norm: true
+      dropout: 0.0
+  mlp:
+  - mlp_cls: dense
+    mlp_kwargs:
+      intermediate_size: 1536
+      dropout: 0.0
+  norm_cls: rmsnorm
+  pos_emb_cls: rope
+  pos_emb_kwargs:
+    rope_theta: 10000.0
+  dropout_embd: 0.0
+
+data:
+  dataset: openwebtext
+  tokenizer_path: tokenizers/custom_bpe_50k
+  data_dir: data/
+  val_split: 0.01
+  num_workers: 4
+
+training:
+  batch_size: 16
+  gradient_accumulation_steps: 16
+  max_steps: 50000
+  mixed_precision: bf16
+  seed: 42
+  quant:
+    enabled: true
+    dtype:
+      weight: fp8_e4m3
+      act: fp8_e4m3
+      input_grad: fp8_e4m3
+      weight_grad: fp8_e4m3
+    scaling:
+      granularity: tensorwise
+    exclude: [lm_head]
+  grad_clip: 1.0
+  checkpoint_dir: checkpoints/fp8_muon/qwen3_51m_fp8_alle4m3_adamw/
+  checkpoint_every: 5000
+  eval_every: 100
+  eval_steps: 100
+
+optimizer:
+  name: adamw
+  lr: 5e-4
+  weight_decay: 0.1
+  betas:
+  - 0.9
+  - 0.95
+
+scheduler:
+  name: cosine
+  warmup_steps: 1500
+  min_lr: 5e-5
+
+logging:
+  wandb_project: pretrain-fp8-muon
+  wandb_run_name: qwen3-51m-fp8-alle4m3-adamw
+  log_every: 10

--- a/experiments/fp8_muon/qwen3_51m_fp8_alle4m3_muon.yaml
+++ b/experiments/fp8_muon/qwen3_51m_fp8_alle4m3_muon.yaml
@@ -37,12 +37,16 @@ training:
   seed: 42
   quant:
     enabled: true
-    dtype_recipe: fp8
+    dtype:
+      weight: fp8_e4m3
+      act: fp8_e4m3
+      input_grad: fp8_e4m3
+      weight_grad: fp8_e4m3
     scaling:
       granularity: tensorwise
     exclude: [lm_head]
   grad_clip: 1.0
-  checkpoint_dir: checkpoints/fp8_muon/qwen3_51m_fp8_muon/
+  checkpoint_dir: checkpoints/fp8_muon/qwen3_51m_fp8_alle4m3_muon/
   checkpoint_every: 5000
   eval_every: 100
   eval_steps: 100
@@ -65,5 +69,5 @@ scheduler:
 
 logging:
   wandb_project: pretrain-fp8-muon
-  wandb_run_name: qwen3-51m-fp8-muon
+  wandb_run_name: qwen3-51m-fp8-alle4m3-muon
   log_every: 10

--- a/experiments/fp8_muon/qwen3_51m_fp8_std_adamw.yaml
+++ b/experiments/fp8_muon/qwen3_51m_fp8_std_adamw.yaml
@@ -37,12 +37,16 @@ training:
   seed: 42
   quant:
     enabled: true
-    dtype_recipe: fp8
+    dtype:
+      weight: fp8_e4m3
+      act: fp8_e4m3
+      input_grad: fp8_e5m2
+      weight_grad: fp8_e5m2
     scaling:
       granularity: tensorwise
     exclude: [lm_head]
   grad_clip: 1.0
-  checkpoint_dir: checkpoints/fp8_muon/qwen3_51m_fp8_adamw/
+  checkpoint_dir: checkpoints/fp8_muon/qwen3_51m_fp8_std_adamw/
   checkpoint_every: 5000
   eval_every: 100
   eval_steps: 100
@@ -62,5 +66,5 @@ scheduler:
 
 logging:
   wandb_project: pretrain-fp8-muon
-  wandb_run_name: qwen3-51m-fp8-adamw
+  wandb_run_name: qwen3-51m-fp8-std-adamw
   log_every: 10

--- a/experiments/fp8_muon/qwen3_51m_fp8_std_muon.yaml
+++ b/experiments/fp8_muon/qwen3_51m_fp8_std_muon.yaml
@@ -1,0 +1,73 @@
+max_seq_len: 1024
+
+model:
+  d_model: 512
+  n_layers: 8
+  vocab_size: 50257
+  attn:
+  - attn_cls: gqa
+    attn_kwargs:
+      n_heads: 8
+      n_kv_heads: 4
+      qk_norm: true
+      dropout: 0.0
+  mlp:
+  - mlp_cls: dense
+    mlp_kwargs:
+      intermediate_size: 1536
+      dropout: 0.0
+  norm_cls: rmsnorm
+  pos_emb_cls: rope
+  pos_emb_kwargs:
+    rope_theta: 10000.0
+  dropout_embd: 0.0
+
+data:
+  dataset: openwebtext
+  tokenizer_path: tokenizers/custom_bpe_50k
+  data_dir: data/
+  val_split: 0.01
+  num_workers: 4
+
+training:
+  batch_size: 16
+  gradient_accumulation_steps: 16
+  max_steps: 50000
+  mixed_precision: bf16
+  seed: 42
+  quant:
+    enabled: true
+    dtype:
+      weight: fp8_e4m3
+      act: fp8_e4m3
+      input_grad: fp8_e5m2
+      weight_grad: fp8_e5m2
+    scaling:
+      granularity: tensorwise
+    exclude: [lm_head]
+  grad_clip: 1.0
+  checkpoint_dir: checkpoints/fp8_muon/qwen3_51m_fp8_std_muon/
+  checkpoint_every: 5000
+  eval_every: 100
+  eval_steps: 100
+
+optimizer:
+  name: muon
+  lr: 5e-4
+  weight_decay: 0.1
+  betas:
+  - 0.9
+  - 0.95
+  muon_momentum: 0.95
+  muon_nesterov: true
+  muon_adjust_lr_fn: match_rms_adamw
+
+scheduler:
+  name: cosine
+  warmup_steps: 1500
+  min_lr: 5e-5
+
+logging:
+  wandb_project: pretrain-fp8-muon
+  wandb_run_name: qwen3-51m-fp8-std-muon
+  log_every: 10

--- a/experiments/fp8_muon/run.sh
+++ b/experiments/fp8_muon/run.sh
@@ -6,15 +6,12 @@
 set -e
 cd "$(dirname "$0")/../.."
 
+precisions=("bf16" "fp8_std" "fp8_alle4m3")
 optimizers=("adamw" "muon")
-recipes=("std" "alle4m3")
 configs=()
-for opt in "${optimizers[@]}"; do
-    configs+=("qwen3_51m_bf16_${opt}")
-done
-for recipe in "${recipes[@]}"; do
+for precision in "${precisions[@]}"; do
     for opt in "${optimizers[@]}"; do
-        configs+=("qwen3_51m_fp8_${recipe}_${opt}")
+        configs+=("qwen3_51m_${precision}_${opt}")
     done
 done
 

--- a/experiments/fp8_muon/run.sh
+++ b/experiments/fp8_muon/run.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
-# Run the qwen3 51M fp8 (tensorwise) sweep: {std, alle4m3} x {adamw, muon}.
+# Run the qwen3 51M optimizer/precision sweep: bf16 baselines + fp8 tensorwise
+# {std, alle4m3} x {adamw, muon}.
 # Usage: nohup bash experiments/fp8_muon/run.sh > logs/fp8_muon_51m.log 2>&1 &
 
 set -e
 cd "$(dirname "$0")/../.."
 
-recipes=("std" "alle4m3")
 optimizers=("adamw" "muon")
+recipes=("std" "alle4m3")
 configs=()
+for opt in "${optimizers[@]}"; do
+    configs+=("qwen3_51m_bf16_${opt}")
+done
 for recipe in "${recipes[@]}"; do
     for opt in "${optimizers[@]}"; do
         configs+=("qwen3_51m_fp8_${recipe}_${opt}")

--- a/experiments/fp8_muon/run.sh
+++ b/experiments/fp8_muon/run.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
-# Run the qwen3 51M fp8 (tensorwise) optimizer comparison: AdamW then Muon.
+# Run the qwen3 51M fp8 (tensorwise) sweep: {std, alle4m3} x {adamw, muon}.
 # Usage: nohup bash experiments/fp8_muon/run.sh > logs/fp8_muon_51m.log 2>&1 &
 
 set -e
 cd "$(dirname "$0")/../.."
 
+recipes=("std" "alle4m3")
 optimizers=("adamw" "muon")
 configs=()
-for opt in "${optimizers[@]}"; do
-    configs+=("qwen3_51m_fp8_${opt}")
+for recipe in "${recipes[@]}"; do
+    for opt in "${optimizers[@]}"; do
+        configs+=("qwen3_51m_fp8_${recipe}_${opt}")
+    done
 done
 
 for config in "${configs[@]}"; do


### PR DESCRIPTION
Sweep {std, alle4m3} x {adamw, muon} at qwen3-51m fp8 tensorwise.
- Rename existing configs to _std_ and make dtype explicit (weight/act e4m3, grad e5m2) instead of the named fp8 recipe.
- Add _alle4m3_ configs: all operands (weight/act/grad) e4m3.
- run.sh sweeps both recipes x both optimizers; README documents the grad-format axis.