### PR TITLE
[chore] merge activation registry behind activation_cls/activation_kwargs

### DIFF
--- a/configs/gpt2_124m.yaml
+++ b/configs/gpt2_124m.yaml
@@ -12,8 +12,7 @@ model:
   mlp:
   - mlp_cls: dense
     mlp_kwargs:
-      activation: gelu
-      gated: false
+      activation_cls: gelu
       bias: true
       dropout: 0.0
   norm_cls: layernorm

--- a/experiments/activation/qwen3_51m_bilinear.yaml
+++ b/experiments/activation/qwen3_51m_bilinear.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 1536
-      activation: bilinear
-      gated: true
+      activation_cls: bilinear
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_bilinear2.yaml
+++ b/experiments/activation/qwen3_51m_bilinear2.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 1536
-      activation: bilinear2
-      gated: true
+      activation_cls: bilinear2
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_geglu.yaml
+++ b/experiments/activation/qwen3_51m_geglu.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 1536
-      activation: gelu
-      gated: true
+      activation_cls: geglu
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_geglu2.yaml
+++ b/experiments/activation/qwen3_51m_geglu2.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 1536
-      activation: gelu2
-      gated: true
+      activation_cls: geglu2
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_gelu.yaml
+++ b/experiments/activation/qwen3_51m_gelu.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 2304
-      activation: gelu
-      gated: false
+      activation_cls: gelu
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_gelu2.yaml
+++ b/experiments/activation/qwen3_51m_gelu2.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 2304
-      activation: gelu2
-      gated: false
+      activation_cls: gelu2
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_leaky_reglu.yaml
+++ b/experiments/activation/qwen3_51m_leaky_reglu.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 1536
-      activation: leaky_relu
-      gated: true
+      activation_cls: leaky_reglu
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_leaky_reglu2.yaml
+++ b/experiments/activation/qwen3_51m_leaky_reglu2.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 1536
-      activation: leaky_relu2
-      gated: true
+      activation_cls: leaky_reglu2
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_leaky_relu.yaml
+++ b/experiments/activation/qwen3_51m_leaky_relu.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 2304
-      activation: leaky_relu
-      gated: false
+      activation_cls: leaky_relu
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_leaky_relu2.yaml
+++ b/experiments/activation/qwen3_51m_leaky_relu2.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 2304
-      activation: leaky_relu2
-      gated: false
+      activation_cls: leaky_relu2
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_powlu.yaml
+++ b/experiments/activation/qwen3_51m_powlu.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 1536
-      activation: powlu
-      gated: true
+      activation_cls: powlu
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_reglu.yaml
+++ b/experiments/activation/qwen3_51m_reglu.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 1536
-      activation: relu
-      gated: true
+      activation_cls: reglu
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_reglu2.yaml
+++ b/experiments/activation/qwen3_51m_reglu2.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 1536
-      activation: relu2
-      gated: true
+      activation_cls: reglu2
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_relu.yaml
+++ b/experiments/activation/qwen3_51m_relu.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 2304
-      activation: relu
-      gated: false
+      activation_cls: relu
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_relu2.yaml
+++ b/experiments/activation/qwen3_51m_relu2.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 2304
-      activation: relu2
-      gated: false
+      activation_cls: relu2
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_silu.yaml
+++ b/experiments/activation/qwen3_51m_silu.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 2304
-      activation: silu
-      gated: false
+      activation_cls: silu
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_silu2.yaml
+++ b/experiments/activation/qwen3_51m_silu2.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 2304
-      activation: silu2
-      gated: false
+      activation_cls: silu2
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_swiglu.yaml
+++ b/experiments/activation/qwen3_51m_swiglu.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 1536
-      activation: silu
-      gated: true
+      activation_cls: swiglu
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation/qwen3_51m_swiglu2.yaml
+++ b/experiments/activation/qwen3_51m_swiglu2.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 1536
-      activation: silu2
-      gated: true
+      activation_cls: swiglu2
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation_limit/README.md
+++ b/experiments/activation_limit/README.md
@@ -1,6 +1,6 @@
 # MLP Activation Limit
 
-Sweep the MLP activation limit (`mlp_kwargs.activation_limit`) at Qwen3-51M in bf16. `activation_limit` bounds the `gate_up_proj` output before SwiGLU, as in gpt-oss's `swiglu_limit` and DeepSeek V4. It is a per-side mapping — `{gate: {min, max}, up: {min, max}}`, every key optional (missing = unbounded on that side). Each `limit L` row below uses the DeepSeek asymmetric form: `gate: {max: L}` (SiLU is already bounded below, so the gate needs no lower bound) and `up: {min: -L, max: L}`.
+Sweep the MLP activation limit (`mlp_kwargs.activation_kwargs.act_limit`) at Qwen3-51M in bf16. `act_limit` bounds the `gate_up_proj` output before SwiGLU, as in gpt-oss's `swiglu_limit` and DeepSeek V4. It is a per-side mapping — `{gate: {min, max}, up: {min, max}}`, every key optional (missing = unbounded on that side). Each `limit L` row below uses the DeepSeek asymmetric form: `gate: {max: L}` (SiLU is already bounded below, so the gate needs no lower bound) and `up: {min: -L, max: L}`.
 
 > Semantics note: earlier runs of this sweep clamped `gate_up_proj` symmetrically to `[-L, L]` *before* the chunk (both gate and up). The current schema clamps gate and up separately, so results at tight limits (1–3) are not directly comparable to any pre-migration numbers; rerun those rows if mixing.
 
@@ -12,7 +12,7 @@ The limit is a capacity constraint in full precision: it removes the tail of the
 
 7 runs. Limits halve each step down to 3, then step to 2 and 1, so the range shrinks geometrically and the tail probes the tight regime.
 
-| Config | `activation_limit` |
+| Config | `act_limit` |
 |---|---|
 | qwen3_51m_bf16 | — |
 | qwen3_51m_act_limit31 | 31 |
@@ -34,7 +34,7 @@ nohup bash experiments/activation_limit/run.sh > logs/activation_limit.log 2>&1 
 
 W&B project: `pretrain-activation-limit`.
 
-| Config | `activation_limit` | Final Val Loss | Δ vs unbounded |
+| Config | `act_limit` | Final Val Loss | Δ vs unbounded |
 |---|---|---|---|
 | qwen3_51m_bf16 | — | | 0 |
 | qwen3_51m_act_limit31 | 31 | | |

--- a/experiments/activation_limit/qwen3_51m_act_limit1.yaml
+++ b/experiments/activation_limit/qwen3_51m_act_limit1.yaml
@@ -15,12 +15,13 @@ model:
     mlp_kwargs:
       intermediate_size: 1536
       dropout: 0.0
-      activation_limit:
-        gate:
-          max: 1.0
-        up:
-          min: -1.0
-          max: 1.0
+      activation_kwargs:
+        act_limit:
+          gate:
+            max: 1.0
+          up:
+            min: -1.0
+            max: 1.0
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation_limit/qwen3_51m_act_limit15.yaml
+++ b/experiments/activation_limit/qwen3_51m_act_limit15.yaml
@@ -15,12 +15,13 @@ model:
     mlp_kwargs:
       intermediate_size: 1536
       dropout: 0.0
-      activation_limit:
-        gate:
-          max: 15.0
-        up:
-          min: -15.0
-          max: 15.0
+      activation_kwargs:
+        act_limit:
+          gate:
+            max: 15.0
+          up:
+            min: -15.0
+            max: 15.0
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation_limit/qwen3_51m_act_limit2.yaml
+++ b/experiments/activation_limit/qwen3_51m_act_limit2.yaml
@@ -15,12 +15,13 @@ model:
     mlp_kwargs:
       intermediate_size: 1536
       dropout: 0.0
-      activation_limit:
-        gate:
-          max: 2.0
-        up:
-          min: -2.0
-          max: 2.0
+      activation_kwargs:
+        act_limit:
+          gate:
+            max: 2.0
+          up:
+            min: -2.0
+            max: 2.0
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation_limit/qwen3_51m_act_limit3.yaml
+++ b/experiments/activation_limit/qwen3_51m_act_limit3.yaml
@@ -15,12 +15,13 @@ model:
     mlp_kwargs:
       intermediate_size: 1536
       dropout: 0.0
-      activation_limit:
-        gate:
-          max: 3.0
-        up:
-          min: -3.0
-          max: 3.0
+      activation_kwargs:
+        act_limit:
+          gate:
+            max: 3.0
+          up:
+            min: -3.0
+            max: 3.0
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation_limit/qwen3_51m_act_limit31.yaml
+++ b/experiments/activation_limit/qwen3_51m_act_limit31.yaml
@@ -15,12 +15,13 @@ model:
     mlp_kwargs:
       intermediate_size: 1536
       dropout: 0.0
-      activation_limit:
-        gate:
-          max: 31.0
-        up:
-          min: -31.0
-          max: 31.0
+      activation_kwargs:
+        act_limit:
+          gate:
+            max: 31.0
+          up:
+            min: -31.0
+            max: 31.0
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/activation_limit/qwen3_51m_act_limit7.yaml
+++ b/experiments/activation_limit/qwen3_51m_act_limit7.yaml
@@ -15,12 +15,13 @@ model:
     mlp_kwargs:
       intermediate_size: 1536
       dropout: 0.0
-      activation_limit:
-        gate:
-          max: 7.0
-        up:
-          min: -7.0
-          max: 7.0
+      activation_kwargs:
+        act_limit:
+          gate:
+            max: 7.0
+          up:
+            min: -7.0
+            max: 7.0
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/int8_activation_limit/README.md
+++ b/experiments/int8_activation_limit/README.md
@@ -1,6 +1,6 @@
 # Activation Limit under Int8 W8A8
 
-Sweep the MLP activation limit (`mlp_kwargs.activation_limit`) at Qwen3-51M under int8 W8A8 tensorwise quantization, against a bf16 baseline. `activation_limit` bounds the `gate_up_proj` output before SwiGLU, as in gpt-oss's `swiglu_limit` and DeepSeek V4. It is a per-side mapping — `{gate: {min, max}, up: {min, max}}`, every key optional (missing = unbounded on that side). Each `limit L` row uses the DeepSeek asymmetric form: `gate: {max: L}` (SiLU is already bounded below) and `up: {min: -L, max: L}`.
+Sweep the MLP activation limit (`mlp_kwargs.activation_kwargs.act_limit`) at Qwen3-51M under int8 W8A8 tensorwise quantization, against a bf16 baseline. `act_limit` bounds the `gate_up_proj` output before SwiGLU, as in gpt-oss's `swiglu_limit` and DeepSeek V4. It is a per-side mapping — `{gate: {min, max}, up: {min, max}}`, every key optional (missing = unbounded on that side). Each `limit L` row uses the DeepSeek asymmetric form: `gate: {max: L}` (SiLU is already bounded below) and `up: {min: -L, max: L}`.
 
 > Semantics note: earlier runs clamped `gate_up_proj` symmetrically to `[-L, L]` *before* the chunk (both gate and up). The current schema clamps gate and up separately, so tight-limit results are not directly comparable to any pre-migration numbers.
 
@@ -14,7 +14,7 @@ The limit also costs loss in full precision on its own. [`activation_limit`](../
 
 9 runs: bf16 baseline, int8 W8A16 (weight-only) reference, unbounded int8 W8A8, and six int8 W8A8 limits. Limits halve each step down to 3, then step to 2 and 1, so the range shrinks geometrically and the tail probes the tight regime.
 
-| Config | Weight | Activation | grad_out | `activation_limit` |
+| Config | Weight | Activation | grad_out | `act_limit` |
 |---|---|---|---|---|
 | qwen3_51m_bf16 | bf16 | bf16 | bf16 | — |
 | qwen3_51m_int8_w8a16 | int8 | bf16 | bf16 | — |
@@ -38,7 +38,7 @@ nohup bash experiments/int8_activation_limit/run.sh > logs/int8_activation_limit
 
 W&B project: `pretrain-int8-activation-limit`.
 
-| Config | Precision | `activation_limit` | Final Val Loss | Δ vs bf16 | Δ vs unbounded int8 |
+| Config | Precision | `act_limit` | Final Val Loss | Δ vs bf16 | Δ vs unbounded int8 |
 |---|---|---|---|---|---|
 | qwen3_51m_bf16 | bf16 | — | | 0 | |
 | qwen3_51m_int8_w8a16 | int8 W8A16 | — | | | |

--- a/experiments/int8_activation_limit/qwen3_51m_int8_w8a8_act_limit1.yaml
+++ b/experiments/int8_activation_limit/qwen3_51m_int8_w8a8_act_limit1.yaml
@@ -15,12 +15,13 @@ model:
     mlp_kwargs:
       intermediate_size: 1536
       dropout: 0.0
-      activation_limit:
-        gate:
-          max: 1.0
-        up:
-          min: -1.0
-          max: 1.0
+      activation_kwargs:
+        act_limit:
+          gate:
+            max: 1.0
+          up:
+            min: -1.0
+            max: 1.0
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/int8_activation_limit/qwen3_51m_int8_w8a8_act_limit15.yaml
+++ b/experiments/int8_activation_limit/qwen3_51m_int8_w8a8_act_limit15.yaml
@@ -15,12 +15,13 @@ model:
     mlp_kwargs:
       intermediate_size: 1536
       dropout: 0.0
-      activation_limit:
-        gate:
-          max: 15.0
-        up:
-          min: -15.0
-          max: 15.0
+      activation_kwargs:
+        act_limit:
+          gate:
+            max: 15.0
+          up:
+            min: -15.0
+            max: 15.0
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/int8_activation_limit/qwen3_51m_int8_w8a8_act_limit2.yaml
+++ b/experiments/int8_activation_limit/qwen3_51m_int8_w8a8_act_limit2.yaml
@@ -15,12 +15,13 @@ model:
     mlp_kwargs:
       intermediate_size: 1536
       dropout: 0.0
-      activation_limit:
-        gate:
-          max: 2.0
-        up:
-          min: -2.0
-          max: 2.0
+      activation_kwargs:
+        act_limit:
+          gate:
+            max: 2.0
+          up:
+            min: -2.0
+            max: 2.0
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/int8_activation_limit/qwen3_51m_int8_w8a8_act_limit3.yaml
+++ b/experiments/int8_activation_limit/qwen3_51m_int8_w8a8_act_limit3.yaml
@@ -15,12 +15,13 @@ model:
     mlp_kwargs:
       intermediate_size: 1536
       dropout: 0.0
-      activation_limit:
-        gate:
-          max: 3.0
-        up:
-          min: -3.0
-          max: 3.0
+      activation_kwargs:
+        act_limit:
+          gate:
+            max: 3.0
+          up:
+            min: -3.0
+            max: 3.0
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/int8_activation_limit/qwen3_51m_int8_w8a8_act_limit31.yaml
+++ b/experiments/int8_activation_limit/qwen3_51m_int8_w8a8_act_limit31.yaml
@@ -15,12 +15,13 @@ model:
     mlp_kwargs:
       intermediate_size: 1536
       dropout: 0.0
-      activation_limit:
-        gate:
-          max: 31.0
-        up:
-          min: -31.0
-          max: 31.0
+      activation_kwargs:
+        act_limit:
+          gate:
+            max: 31.0
+          up:
+            min: -31.0
+            max: 31.0
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/int8_activation_limit/qwen3_51m_int8_w8a8_act_limit7.yaml
+++ b/experiments/int8_activation_limit/qwen3_51m_int8_w8a8_act_limit7.yaml
@@ -15,12 +15,13 @@ model:
     mlp_kwargs:
       intermediate_size: 1536
       dropout: 0.0
-      activation_limit:
-        gate:
-          max: 7.0
-        up:
-          min: -7.0
-          max: 7.0
+      activation_kwargs:
+        act_limit:
+          gate:
+            max: 7.0
+          up:
+            min: -7.0
+            max: 7.0
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/mlp_gated/qwen3_0.5b_mlp_gated_off.yaml
+++ b/experiments/mlp_gated/qwen3_0.5b_mlp_gated_off.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 6144
-      activation: silu
-      gated: false
+      activation_cls: silu
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/mlp_gated/qwen3_0.5b_mlp_gated_on.yaml
+++ b/experiments/mlp_gated/qwen3_0.5b_mlp_gated_on.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 4096
-      activation: silu
-      gated: true
+      activation_cls: swiglu
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/mlp_gated/qwen3_57m_mlp_gated_off.yaml
+++ b/experiments/mlp_gated/qwen3_57m_mlp_gated_off.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 3072
-      activation: silu
-      gated: false
+      activation_cls: silu
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/mlp_gated/qwen3_57m_mlp_gated_on.yaml
+++ b/experiments/mlp_gated/qwen3_57m_mlp_gated_on.yaml
@@ -13,8 +13,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 2048
-      activation: silu
-      gated: true
+      activation_cls: swiglu
   norm_cls: rmsnorm
   pos_emb_cls: rope
   pos_emb_kwargs:

--- a/experiments/moe_layer0_balance/README.md
+++ b/experiments/moe_layer0_balance/README.md
@@ -40,7 +40,7 @@ d_model, 8 layers, 64 routed experts + 2 always-on shared experts, top-6
 routed, no expert capacity limit, `expert_bias: true` / `aux_loss: false`,
 sigmoid router, muon lr 1e-3, warmup 1500. Active MoE FFN width
 `(k + s)·intermediate_size = (6+2)·192 = 1536`; `l0dense`'s layer-0 dense
-MLP uses `intermediate_size: 1536, activation: silu, gated: true` to match it
+MLP uses `intermediate_size: 1536, activation_cls: silu, gated: true` to match it
 (SwiGLU, compute-comparable to a routed+shared MoE layer).
 
 | Param | Value |

--- a/experiments/moe_layer0_balance/qwen3_171m_a51m_l0dense.yaml
+++ b/experiments/moe_layer0_balance/qwen3_171m_a51m_l0dense.yaml
@@ -14,8 +14,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 1536
-      activation: silu
-      gated: true
+      activation_cls: swiglu
     layer_idx: [0]
   - mlp_cls: moe
     mlp_kwargs:

--- a/experiments/moe_layer0_balance/qwen3_171m_a51m_l0dense_l0mlplr0.5.yaml
+++ b/experiments/moe_layer0_balance/qwen3_171m_a51m_l0dense_l0mlplr0.5.yaml
@@ -14,8 +14,7 @@ model:
   - mlp_cls: dense
     mlp_kwargs:
       intermediate_size: 1536
-      activation: silu
-      gated: true
+      activation_cls: swiglu
     layer_idx: [0]
   - mlp_cls: moe
     mlp_kwargs:

--- a/src/layers/activation.py
+++ b/src/layers/activation.py
@@ -1,3 +1,5 @@
+from typing import Callable, NamedTuple
+
 import torch
 import torch.nn.functional as F
 
@@ -5,99 +7,252 @@ import torch.nn.functional as F
 # --- Unary activations: x → act(x) ---
 
 
-def relu(x: torch.Tensor) -> torch.Tensor:
+def relu(x: torch.Tensor, act_limit: dict | None = None) -> torch.Tensor:
+    if act_limit and "up" in act_limit:
+        x = x.clamp(**act_limit["up"])
     return F.relu(x)
 
 
-def gelu(x: torch.Tensor) -> torch.Tensor:
+def gelu(x: torch.Tensor, act_limit: dict | None = None) -> torch.Tensor:
+    if act_limit and "up" in act_limit:
+        x = x.clamp(**act_limit["up"])
     return F.gelu(x)
 
 
-def silu(x: torch.Tensor) -> torch.Tensor:
-    return F.silu(x)
+def silu(
+    x: torch.Tensor, alpha: float = 1.0, act_limit: dict | None = None
+) -> torch.Tensor:
+    """x * sigmoid(alpha * x). alpha scales only the sigmoid argument, so
+    alpha=1.0 is exactly F.silu (gpt-oss uses alpha=1.702)."""
+    if act_limit and "up" in act_limit:
+        x = x.clamp(**act_limit["up"])
+    if alpha == 1.0:
+        return F.silu(x)
+    return x * torch.sigmoid(alpha * x)
 
 
-def silu_openai(x: torch.Tensor) -> torch.Tensor:
-    alpha = 1.702
-    limit = 7.0
-    gated = x.clamp(max=limit)
-    return gated * torch.sigmoid(alpha * gated)
+def leaky_relu(
+    x: torch.Tensor, negative_slope: float = 0.01, act_limit: dict | None = None
+) -> torch.Tensor:
+    if act_limit and "up" in act_limit:
+        x = x.clamp(**act_limit["up"])
+    return F.leaky_relu(x, negative_slope)
 
 
-def leaky_relu(x: torch.Tensor) -> torch.Tensor:
-    return F.leaky_relu(x, 0.01)
-
-
-def relu2(x: torch.Tensor) -> torch.Tensor:
+def relu2(x: torch.Tensor, act_limit: dict | None = None) -> torch.Tensor:
+    if act_limit and "up" in act_limit:
+        x = x.clamp(**act_limit["up"])
     return F.relu(x) ** 2
 
 
-def gelu2(x: torch.Tensor) -> torch.Tensor:
+def gelu2(x: torch.Tensor, act_limit: dict | None = None) -> torch.Tensor:
+    if act_limit and "up" in act_limit:
+        x = x.clamp(**act_limit["up"])
     return F.gelu(x) ** 2
 
 
-def silu2(x: torch.Tensor) -> torch.Tensor:
-    return F.silu(x) ** 2
+def silu2(
+    x: torch.Tensor, alpha: float = 1.0, act_limit: dict | None = None
+) -> torch.Tensor:
+    if act_limit and "up" in act_limit:
+        x = x.clamp(**act_limit["up"])
+    if alpha == 1.0:
+        return F.silu(x) ** 2
+    return (x * torch.sigmoid(alpha * x)) ** 2
 
 
-def leaky_relu2(x: torch.Tensor) -> torch.Tensor:
-    return F.leaky_relu(x, 0.01) ** 2
+def leaky_relu2(
+    x: torch.Tensor, negative_slope: float = 0.01, act_limit: dict | None = None
+) -> torch.Tensor:
+    if act_limit and "up" in act_limit:
+        x = x.clamp(**act_limit["up"])
+    return F.leaky_relu(x, negative_slope) ** 2
 
 
-# --- Gated (GLU) activations: (gate, up) → act(gate) * up ---
+# --- Gated (GLU) activations: (gate, up) → act(gate) * (up + up_shift) ---
 
 
-def relu_glu(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+def reglu(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    up_shift: float = 0.0,
+    act_limit: dict | None = None,
+) -> torch.Tensor:
+    if act_limit:
+        if "gate" in act_limit:
+            gate = gate.clamp(**act_limit["gate"])
+        if "up" in act_limit:
+            up = up.clamp(**act_limit["up"])
+    if up_shift != 0.0:
+        up = up + up_shift
     return F.relu(gate) * up
 
 
-def gelu_glu(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+def geglu(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    up_shift: float = 0.0,
+    act_limit: dict | None = None,
+) -> torch.Tensor:
+    if act_limit:
+        if "gate" in act_limit:
+            gate = gate.clamp(**act_limit["gate"])
+        if "up" in act_limit:
+            up = up.clamp(**act_limit["up"])
+    if up_shift != 0.0:
+        up = up + up_shift
     return F.gelu(gate) * up
 
 
-def silu_glu(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
-    return F.silu(gate) * up
+def swiglu(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    alpha: float = 1.0,
+    up_shift: float = 0.0,
+    act_limit: dict | None = None,
+) -> torch.Tensor:
+    """
+    SwiGLU: SiLU's gated form.
+    gpt-oss's variant is alpha=1.702, up_shift=1.0, act_limit=±7.
+    """
+    if act_limit:
+        if "gate" in act_limit:
+            gate = gate.clamp(**act_limit["gate"])
+        if "up" in act_limit:
+            up = up.clamp(**act_limit["up"])
+    if up_shift != 0.0:
+        up = up + up_shift
+    if alpha == 1.0:
+        return F.silu(gate) * up
+    return gate * torch.sigmoid(alpha * gate) * up
 
 
-def silu_openai_glu(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
-    alpha = 1.702
-    limit = 7.0
-    gated = gate.clamp(max=limit)
-    shifted_up = up.clamp(min=-limit, max=limit) + 1.0
-    return gated * torch.sigmoid(alpha * gated) * shifted_up
+def leaky_reglu(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    negative_slope: float = 0.01,
+    up_shift: float = 0.0,
+    act_limit: dict | None = None,
+) -> torch.Tensor:
+    if act_limit:
+        if "gate" in act_limit:
+            gate = gate.clamp(**act_limit["gate"])
+        if "up" in act_limit:
+            up = up.clamp(**act_limit["up"])
+    if up_shift != 0.0:
+        up = up + up_shift
+    return F.leaky_relu(gate, negative_slope) * up
 
 
-def leaky_relu_glu(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
-    return F.leaky_relu(gate, 0.01) * up
-
-
-def relu2_glu(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+def reglu2(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    up_shift: float = 0.0,
+    act_limit: dict | None = None,
+) -> torch.Tensor:
+    if act_limit:
+        if "gate" in act_limit:
+            gate = gate.clamp(**act_limit["gate"])
+        if "up" in act_limit:
+            up = up.clamp(**act_limit["up"])
+    if up_shift != 0.0:
+        up = up + up_shift
     return (F.relu(gate) ** 2) * up
 
 
-def gelu2_glu(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+def geglu2(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    up_shift: float = 0.0,
+    act_limit: dict | None = None,
+) -> torch.Tensor:
+    if act_limit:
+        if "gate" in act_limit:
+            gate = gate.clamp(**act_limit["gate"])
+        if "up" in act_limit:
+            up = up.clamp(**act_limit["up"])
+    if up_shift != 0.0:
+        up = up + up_shift
     return (F.gelu(gate) ** 2) * up
 
 
-def silu2_glu(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
-    return (F.silu(gate) ** 2) * up
+def swiglu2(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    alpha: float = 1.0,
+    up_shift: float = 0.0,
+    act_limit: dict | None = None,
+) -> torch.Tensor:
+    if act_limit:
+        if "gate" in act_limit:
+            gate = gate.clamp(**act_limit["gate"])
+        if "up" in act_limit:
+            up = up.clamp(**act_limit["up"])
+    if up_shift != 0.0:
+        up = up + up_shift
+    if alpha == 1.0:
+        return (F.silu(gate) ** 2) * up
+    return ((gate * torch.sigmoid(alpha * gate)) ** 2) * up
 
 
-def leaky_relu2_glu(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
-    return (F.leaky_relu(gate, 0.01) ** 2) * up
+def leaky_reglu2(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    negative_slope: float = 0.01,
+    up_shift: float = 0.0,
+    act_limit: dict | None = None,
+) -> torch.Tensor:
+    if act_limit:
+        if "gate" in act_limit:
+            gate = gate.clamp(**act_limit["gate"])
+        if "up" in act_limit:
+            up = up.clamp(**act_limit["up"])
+    if up_shift != 0.0:
+        up = up + up_shift
+    return (F.leaky_relu(gate, negative_slope) ** 2) * up
 
 
-def bilinear(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+def bilinear(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    up_shift: float = 0.0,
+    act_limit: dict | None = None,
+) -> torch.Tensor:
     """Bilinear GLU: gate * up. No unary activation. Shazeer 2020."""
+    if act_limit:
+        if "gate" in act_limit:
+            gate = gate.clamp(**act_limit["gate"])
+        if "up" in act_limit:
+            up = up.clamp(**act_limit["up"])
+    if up_shift != 0.0:
+        up = up + up_shift
     return gate * up
 
 
-def bilinear2(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+def bilinear2(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    up_shift: float = 0.0,
+    act_limit: dict | None = None,
+) -> torch.Tensor:
     """Squared Bilinear GLU: gate² * up."""
+    if act_limit:
+        if "gate" in act_limit:
+            gate = gate.clamp(**act_limit["gate"])
+        if "up" in act_limit:
+            up = up.clamp(**act_limit["up"])
+    if up_shift != 0.0:
+        up = up + up_shift
     return (gate**2) * up
 
 
-def powlu(x: torch.Tensor) -> torch.Tensor:
+def powlu(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    m: float = 3.0,
+    up_shift: float = 0.0,
+    act_limit: dict | None = None,
+) -> torch.Tensor:
     """PowLU helper: arXiv:2605.25704 (May 2026), m=3.0.
 
     Piecewise:
@@ -116,40 +271,47 @@ def powlu(x: torch.Tensor) -> torch.Tensor:
     The outer `torch.where(x > 0, pos, neg)` selects the correct branch;
     when x > 0, safe_x == x, so the forward value is unchanged.
     """
-    m = 3.0
-    safe_x = torch.where(x > 0, x, torch.ones_like(x))
-    exponent = m / (torch.sqrt(safe_x) + 1.0)
-    pos = x * (safe_x**exponent) * torch.sigmoid(x)
-    neg = x * x * torch.sigmoid(x)
-    return torch.where(x > 0, pos, neg)
+    if act_limit:
+        if "gate" in act_limit:
+            gate = gate.clamp(**act_limit["gate"])
+        if "up" in act_limit:
+            up = up.clamp(**act_limit["up"])
+    if up_shift != 0.0:
+        up = up + up_shift
+    safe_gate = torch.where(gate > 0, gate, torch.ones_like(gate))
+    exponent = m / (torch.sqrt(safe_gate) + 1.0)
+    pos = gate * (safe_gate**exponent) * torch.sigmoid(gate)
+    neg = gate * gate * torch.sigmoid(gate)
+    return torch.where(gate > 0, pos, neg) * up
 
 
-def powlu_glu(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
-    return powlu(gate) * up
+class Activation(NamedTuple):
+    """Registry entry: the function, plus the arity its name already implies."""
+
+    fn: Callable
+    gated: bool
 
 
-UNGATED_ACTIVATIONS = {
-    "relu": relu,
-    "gelu": gelu,
-    "silu": silu,
-    "silu_openai": silu_openai,
-    "leaky_relu": leaky_relu,
-    "relu2": relu2,
-    "gelu2": gelu2,
-    "silu2": silu2,
-    "leaky_relu2": leaky_relu2,
-}
-GATED_ACTIVATIONS = {
-    "relu": relu_glu,
-    "gelu": gelu_glu,
-    "silu": silu_glu,
-    "silu_openai": silu_openai_glu,
-    "leaky_relu": leaky_relu_glu,
-    "relu2": relu2_glu,
-    "gelu2": gelu2_glu,
-    "silu2": silu2_glu,
-    "leaky_relu2": leaky_relu2_glu,
-    "bilinear": bilinear,
-    "bilinear2": bilinear2,
-    "powlu": powlu_glu,
+# The name alone says gated or unary -- "swiglu" is SiLU's gated form, "silu" the
+# unary one -- so no separate `gated` config key is needed.
+ACT_REGISTRY = {
+    "relu": Activation(relu, False),
+    "gelu": Activation(gelu, False),
+    "silu": Activation(silu, False),
+    "leaky_relu": Activation(leaky_relu, False),
+    "relu2": Activation(relu2, False),
+    "gelu2": Activation(gelu2, False),
+    "silu2": Activation(silu2, False),
+    "leaky_relu2": Activation(leaky_relu2, False),
+    "reglu": Activation(reglu, True),
+    "geglu": Activation(geglu, True),
+    "swiglu": Activation(swiglu, True),
+    "leaky_reglu": Activation(leaky_reglu, True),
+    "reglu2": Activation(reglu2, True),
+    "geglu2": Activation(geglu2, True),
+    "swiglu2": Activation(swiglu2, True),
+    "leaky_reglu2": Activation(leaky_reglu2, True),
+    "bilinear": Activation(bilinear, True),
+    "bilinear2": Activation(bilinear2, True),
+    "powlu": Activation(powlu, True),
 }

--- a/src/layers/attention.py
+++ b/src/layers/attention.py
@@ -70,8 +70,14 @@ class MultiHeadAttention(nn.Module):
 
     @classmethod
     def compute_flops(
-        cls, d_model, max_seq_len, *, n_heads, bias=False, qk_norm=False, **_
-    ):
+        cls,
+        d_model: int,
+        max_seq_len: int,
+        n_heads: int,
+        bias: bool = False,
+        qk_norm: bool = False,
+        **_: object,
+    ) -> int:
         head_dim = d_model // n_heads
         n_kv = n_heads
         qkv = 2 * d_model * (n_heads + 2 * n_kv) * head_dim
@@ -84,7 +90,12 @@ class MultiHeadAttention(nn.Module):
 
     @classmethod
     def compute_parameters(
-        cls, d_model, *, n_heads, bias=False, qk_norm=False, **_
+        cls,
+        d_model: int,
+        n_heads: int,
+        bias: bool = False,
+        qk_norm: bool = False,
+        **_: object,
     ) -> int:
         head_dim = d_model // n_heads
         n_kv = n_heads
@@ -164,14 +175,14 @@ class GroupedQueryAttention(nn.Module):
     @classmethod
     def compute_flops(
         cls,
-        d_model,
-        max_seq_len,
-        n_heads,
-        n_kv_heads=None,
-        bias=False,
-        qk_norm=False,
-        **_,
-    ):
+        d_model: int,
+        max_seq_len: int,
+        n_heads: int,
+        n_kv_heads: int | None = None,
+        bias: bool = False,
+        qk_norm: bool = False,
+        **_: object,
+    ) -> int:
         n_kv = n_kv_heads or n_heads
         head_dim = d_model // n_heads
         qkv = 2 * d_model * (n_heads + 2 * n_kv) * head_dim
@@ -184,7 +195,13 @@ class GroupedQueryAttention(nn.Module):
 
     @classmethod
     def compute_parameters(
-        cls, d_model, *, n_heads, n_kv_heads=None, bias=False, qk_norm=False, **_
+        cls,
+        d_model: int,
+        n_heads: int,
+        n_kv_heads: int | None = None,
+        bias: bool = False,
+        qk_norm: bool = False,
+        **_: object,
     ) -> int:
         n_kv = n_kv_heads or n_heads
         head_dim = d_model // n_heads
@@ -293,17 +310,17 @@ class MultiHeadLatentAttention(nn.Module):
     @classmethod
     def compute_flops(
         cls,
-        d_model,
-        max_seq_len,
-        n_heads,
-        qk_nope_head_dim,
-        qk_rope_head_dim,
-        v_head_dim,
-        kv_lora_rank,
-        q_lora_rank=0,
-        bias=False,
-        **_,
-    ):
+        d_model: int,
+        max_seq_len: int,
+        n_heads: int,
+        qk_nope_head_dim: int,
+        qk_rope_head_dim: int,
+        v_head_dim: int,
+        kv_lora_rank: int,
+        q_lora_rank: int = 0,
+        bias: bool = False,
+        **_: object,
+    ) -> int:
         qk_head = qk_nope_head_dim + qk_rope_head_dim
         b = lambda out: out if bias else 0  # noqa: E731
         if q_lora_rank > 0:
@@ -333,15 +350,15 @@ class MultiHeadLatentAttention(nn.Module):
     @classmethod
     def compute_parameters(
         cls,
-        d_model,
-        n_heads,
-        qk_nope_head_dim,
-        qk_rope_head_dim,
-        v_head_dim,
-        kv_lora_rank,
-        q_lora_rank=0,
-        bias=False,
-        **_,
+        d_model: int,
+        n_heads: int,
+        qk_nope_head_dim: int,
+        qk_rope_head_dim: int,
+        v_head_dim: int,
+        kv_lora_rank: int,
+        q_lora_rank: int = 0,
+        bias: bool = False,
+        **_: object,
     ) -> int:
         qk_head = qk_nope_head_dim + qk_rope_head_dim
         b = lambda out: out if bias else 0  # noqa: E731

--- a/src/layers/mlp.py
+++ b/src/layers/mlp.py
@@ -1,22 +1,10 @@
+from functools import partial
+
 import torch
 import torch.nn as nn
 
 from src.kernel.ops.gemm import grouped_mm
-from src.layers.activation import GATED_ACTIVATIONS, UNGATED_ACTIVATIONS
-
-
-def _apply_act_limit(t: torch.Tensor, act_limit: dict, side: str) -> torch.Tensor:
-    """Clamp a tensor by the min/max bounds for one side of activation_limit.
-
-    `side` is "gate" or "up"; a missing side or bound is unbounded there. Gated
-    blocks clamp gate and up separately (DeepSeek-V4: SiLU is already bounded
-    below, so gate typically sets only max); ungated blocks pass their single
-    tensor with side="up".
-    """
-    bounds = act_limit.get(side)
-    if not isinstance(bounds, dict):
-        return t
-    return t.clamp(bounds.get("min"), bounds.get("max"))
+from src.layers.activation import ACT_REGISTRY
 
 
 class GroupedGemmFn(torch.autograd.Function):
@@ -64,7 +52,6 @@ def grouped_mlp(
     b_in: torch.Tensor = None,
     b_down: torch.Tensor = None,
     expert_mm=grouped_mm_fn,
-    act_limit: dict | None = None,
 ) -> torch.Tensor:
     dev = x.device.type
     if torch.is_autocast_enabled(dev):
@@ -79,38 +66,31 @@ def grouped_mlp(
     # the per-expert bias is (E, out) and rides in the GEMM epilogue
     h = expert_mm(x, w_in.mT, offs, bias=b_in, projection="gate_up")
     if gated:
-        gate, up = h.chunk(2, dim=-1)
-        if act_limit is not None:
-            gate = _apply_act_limit(gate, act_limit, "gate")
-            up = _apply_act_limit(up, act_limit, "up")
-        h = act_fn(gate, up)
+        h = act_fn(*h.chunk(2, dim=-1))
     else:
-        if act_limit is not None:
-            h = _apply_act_limit(h, act_limit, "up")
         h = act_fn(h)
     return expert_mm(h, w_down.mT, offs, bias=b_down, projection="down")
 
 
 class DenseMLPBlock(nn.Module):
-    """Dense feed-forward block, ungated or GLU-family (gated=True + silu = SwiGLU)."""
+    """Dense feed-forward block; the activation's name picks unary or GLU-family."""
 
     def __init__(
         self,
         d_model: int,
         intermediate_size: int,
-        activation: str = "silu",
-        activation_limit: dict | None = None,
-        gated: bool = True,
+        activation_cls: str = "swiglu",
+        activation_kwargs: dict | None = None,
         bias: bool = False,
         dropout: float = 0.0,
     ):
         super().__init__()
         # Defaults/validation (intermediate_size, activation) live in ModelConfig.
-        registry = GATED_ACTIVATIONS if gated else UNGATED_ACTIVATIONS
-        self.gated = gated
-        self.act_fn = registry[activation]
-        self.act_limit = activation_limit
-        if gated:
+        # The activation's name carries the arity, so `gated` is derived, not passed.
+        activation = ACT_REGISTRY[activation_cls]
+        self.gated = activation.gated
+        self.act_fn = partial(activation.fn, **(activation_kwargs or {}))
+        if self.gated:
             self.gate_up_proj = nn.Linear(d_model, 2 * intermediate_size, bias=bias)
         else:
             self.up_proj = nn.Linear(d_model, intermediate_size, bias=bias)
@@ -118,23 +98,23 @@ class DenseMLPBlock(nn.Module):
         self.dropout = nn.Dropout(dropout)
 
     def forward(self, x: torch.Tensor) -> tuple:
-        # gpt-oss/deepseek-v4 style swiglu clamping: gate and up bounded per side
         if self.gated:
-            gate, up = self.gate_up_proj(x).chunk(2, dim=-1)
-            if self.act_limit is not None:
-                gate = _apply_act_limit(gate, self.act_limit, "gate")
-                up = _apply_act_limit(up, self.act_limit, "up")
-            hidden = self.act_fn(gate, up)
+            hidden = self.act_fn(*self.gate_up_proj(x).chunk(2, dim=-1))
         else:
-            h = self.up_proj(x)
-            if self.act_limit is not None:
-                h = _apply_act_limit(h, self.act_limit, "up")
-            hidden = self.act_fn(h)
+            hidden = self.act_fn(self.up_proj(x))
         return self.dropout(self.down_proj(hidden)), None
 
     @classmethod
-    def compute_flops(cls, d_model, intermediate_size, gated=True, bias=False, **_):
+    def compute_flops(
+        cls,
+        d_model: int,
+        intermediate_size: int,
+        activation_cls: str = "swiglu",
+        bias: bool = False,
+        **_: object,
+    ) -> int:
         d_ff = intermediate_size
+        gated = ACT_REGISTRY[activation_cls].gated
         if gated:
             matmul = 6 * d_model * d_ff
             b = (2 * d_ff + d_model) if bias else 0
@@ -145,9 +125,16 @@ class DenseMLPBlock(nn.Module):
 
     @classmethod
     def compute_parameters(
-        cls, d_model, *, intermediate_size, gated=True, bias=False, active=False, **_
+        cls,
+        d_model: int,
+        intermediate_size: int,
+        activation_cls: str = "swiglu",
+        bias: bool = False,
+        active: bool = False,
+        **_: object,
     ) -> int:
         d_ff = intermediate_size
+        gated = ACT_REGISTRY[activation_cls].gated
         if gated:
             weights = 3 * d_ff * d_model  # gate_up (2*d_ff x d) + down (d x d_ff)
             b = (2 * d_ff + d_model) if bias else 0
@@ -276,14 +263,18 @@ class MoERouter(nn.Module):
             self.expert_bias.update(expert_counts)
 
     @classmethod
-    def compute_flops(cls, d_model: int, n_experts: int, expert_bias=False) -> int:
+    def compute_flops(
+        cls, d_model: int, n_experts: int, expert_bias: bool = False
+    ) -> int:
         flops = 2 * d_model * n_experts  # gate matmul (no bias)
         if expert_bias:
             flops += ExpertBias.compute_flops(n_experts)
         return flops
 
     @classmethod
-    def compute_parameters(cls, d_model: int, n_experts: int, expert_bias=False):
+    def compute_parameters(
+        cls, d_model: int, n_experts: int, expert_bias: bool = False
+    ) -> int:
         params = d_model * n_experts  # gate, no bias
         if expert_bias:
             params += ExpertBias.compute_parameters(n_experts)
@@ -305,9 +296,8 @@ class SparseMoEBlock(nn.Module):
         expert_bias: bool = False,
         expert_bias_update_rate: float = 0.001,
         router_score_fn: str = "sigmoid",
-        activation: str = "silu",
-        activation_limit: dict | None = None,
-        gated: bool = True,
+        activation_cls: str = "swiglu",
+        activation_kwargs: dict | None = None,
         bias: bool = False,
         dropout: float = 0.0,
         latent_moe: bool = False,
@@ -318,7 +308,8 @@ class SparseMoEBlock(nn.Module):
             raise ValueError(
                 "aux_loss and expert_bias are mutually exclusive MoE balancing strategies"
             )
-        registry = GATED_ACTIVATIONS if gated else UNGATED_ACTIVATIONS
+        activation = ACT_REGISTRY[activation_cls]
+        self.gated = activation.gated
         self.n_routed_experts = n_routed_experts
         self.n_routed_experts_per_token = n_routed_experts_per_token
         self.n_shared_experts = n_shared_experts
@@ -327,9 +318,7 @@ class SparseMoEBlock(nn.Module):
         self.router_score_fn = router_score_fn
         self.expert_bias = expert_bias
         self.expert_bias_update_rate = expert_bias_update_rate
-        self.gated = gated
-        self.act_fn = registry[activation]
-        self.act_limit = activation_limit
+        self.act_fn = partial(activation.fn, **(activation_kwargs or {}))
         self.latent_moe = latent_moe
         self.latent_dim = latent_dim
         expert_dim = latent_dim if latent_moe else d_model
@@ -349,9 +338,8 @@ class SparseMoEBlock(nn.Module):
             self.shared_expert = DenseMLPBlock(
                 d_model,
                 intermediate_size=n_shared_experts * intermediate_size,
-                activation=activation,
-                activation_limit=activation_limit,
-                gated=gated,
+                activation_cls=activation_cls,
+                activation_kwargs=activation_kwargs,
                 bias=bias,
                 dropout=dropout,
             )
@@ -360,7 +348,7 @@ class SparseMoEBlock(nn.Module):
 
         # Stacked expert weights: (E, out, in) following nn.Linear convention.
         # Gated path fuses gate and up into one tensor (one bmm vs two).
-        if gated:
+        if self.gated:
             self.expert_gate_up = nn.Parameter(
                 torch.empty(n_routed_experts, 2 * intermediate_size, expert_dim)
             )
@@ -448,7 +436,6 @@ class SparseMoEBlock(nn.Module):
             b_in=b_in,
             b_down=self.expert_down_bias,
             expert_mm=self.expert_mm,
-            act_limit=self.act_limit,
         )
         expert_out = expert_out * weights_sorted
         expert_out = self.expert_dropout(expert_out)
@@ -493,19 +480,20 @@ class SparseMoEBlock(nn.Module):
     @classmethod
     def compute_flops(
         cls,
-        d_model,
-        intermediate_size,
-        n_routed_experts,
-        n_routed_experts_per_token=2,
-        n_shared_experts=0,
-        gated=True,
-        bias=False,
-        expert_bias=False,
-        latent_moe=False,
-        latent_dim=None,
-        **_,
-    ):
+        d_model: int,
+        intermediate_size: int,
+        n_routed_experts: int,
+        n_routed_experts_per_token: int = 2,
+        n_shared_experts: int = 0,
+        activation_cls: str = "swiglu",
+        bias: bool = False,
+        expert_bias: bool = False,
+        latent_moe: bool = False,
+        latent_dim: int | None = None,
+        **_: object,
+    ) -> int:
         d_ff = intermediate_size
+        gated = ACT_REGISTRY[activation_cls].gated
         edim = latent_dim if latent_moe else d_model
         router = MoERouter.compute_flops(
             d_model, n_routed_experts, expert_bias=expert_bias
@@ -521,7 +509,7 @@ class SparseMoEBlock(nn.Module):
             DenseMLPBlock.compute_flops(
                 d_model,
                 intermediate_size=n_shared_experts * d_ff,
-                gated=gated,
+                activation_cls=activation_cls,
                 bias=bias,
             )
             if n_shared_experts > 0
@@ -532,20 +520,21 @@ class SparseMoEBlock(nn.Module):
     @classmethod
     def compute_parameters(
         cls,
-        d_model,
-        intermediate_size,
-        n_routed_experts,
-        n_routed_experts_per_token=2,
-        n_shared_experts=0,
-        gated=True,
-        bias=False,
-        expert_bias=False,
-        latent_moe=False,
-        latent_dim=None,
-        active=False,
-        **_,
+        d_model: int,
+        intermediate_size: int,
+        n_routed_experts: int,
+        n_routed_experts_per_token: int = 2,
+        n_shared_experts: int = 0,
+        activation_cls: str = "swiglu",
+        bias: bool = False,
+        expert_bias: bool = False,
+        latent_moe: bool = False,
+        latent_dim: int | None = None,
+        active: bool = False,
+        **_: object,
     ) -> int:
         d_ff = intermediate_size
+        gated = ACT_REGISTRY[activation_cls].gated
         edim = latent_dim if latent_moe else d_model
         router = MoERouter.compute_parameters(
             d_model, n_routed_experts, expert_bias=expert_bias
@@ -565,7 +554,7 @@ class SparseMoEBlock(nn.Module):
             DenseMLPBlock.compute_parameters(
                 d_model,
                 intermediate_size=n_shared_experts * d_ff,
-                gated=gated,
+                activation_cls=activation_cls,
                 bias=bias,
             )
             if n_shared_experts > 0

--- a/src/layers/norm.py
+++ b/src/layers/norm.py
@@ -10,7 +10,7 @@ class RMSNorm(nn.RMSNorm):
         return super().forward(x.to(self.weight.dtype)).to(x.dtype)
 
     @classmethod
-    def compute_parameters(cls, d_model, **_) -> int:
+    def compute_parameters(cls, d_model: int, **_: object) -> int:
         return d_model  # weight only, no bias
 
 
@@ -19,7 +19,7 @@ class LayerNorm(nn.LayerNorm):
         super().__init__(d_model, eps=eps, elementwise_affine=True, bias=bias)
 
     @classmethod
-    def compute_parameters(cls, d_model, bias=True, **_) -> int:
+    def compute_parameters(cls, d_model: int, bias: bool = True, **_: object) -> int:
         return d_model * (2 if bias else 1)  # weight + optional bias
 
 

--- a/src/layers/pos_emb.py
+++ b/src/layers/pos_emb.py
@@ -18,7 +18,7 @@ class LearnedPositionalEmbedding(nn.Module):
         return x + self.embedding(pos)
 
     @classmethod
-    def compute_parameters(cls, max_seq_len, d_model, **_) -> int:
+    def compute_parameters(cls, max_seq_len: int, d_model: int, **_: object) -> int:
         return max_seq_len * d_model
 
 
@@ -65,7 +65,7 @@ class RoPE(nn.Module):
         return _apply_rope(x, cos, sin)
 
     @classmethod
-    def compute_parameters(cls, max_seq_len, d_model, **_) -> int:
+    def compute_parameters(cls, max_seq_len: int, d_model: int, **_: object) -> int:
         return 0  # cos/sin are buffers, not trainable params
 
 

--- a/src/layers/residual.py
+++ b/src/layers/residual.py
@@ -1,7 +1,12 @@
+from typing import TYPE_CHECKING
+
 import torch
 import torch.nn as nn
 
 from src.layers.norm import LayerNorm, RMSNorm
+
+if TYPE_CHECKING:
+    from src.utils.config import ModelConfig
 
 
 def _aggregate(V: torch.Tensor, K: torch.Tensor, w_proj: torch.Tensor) -> torch.Tensor:
@@ -28,12 +33,14 @@ class BaseResidual(nn.Module):
         raise NotImplementedError
 
     @classmethod
-    def compute_flops(cls, config, max_seq_len: int, layer_idx: int) -> int:
+    def compute_flops(
+        cls, config: "ModelConfig", max_seq_len: int, layer_idx: int
+    ) -> int:
         """Forward FLOPs per token for ONE residual slot; a plain add counts as 0."""
         return 0
 
     @classmethod
-    def compute_parameters(cls, config) -> int:
+    def compute_parameters(cls, config: "ModelConfig") -> int:
         """Trainable params for ONE residual slot. Default 0: a plain add has none."""
         return 0
 
@@ -75,13 +82,15 @@ class AttnResidual(BaseResidual):
         return x + r, ctx
 
     @classmethod
-    def compute_flops(cls, config, max_seq_len: int, layer_idx: int) -> int:
+    def compute_flops(
+        cls, config: "ModelConfig", max_seq_len: int, layer_idx: int
+    ) -> int:
         seal = config.residual_kwargs.get("seal_block_size", 1)
         n_ctx = layer_idx // seal + 1
         return 7 * n_ctx * config.d_model
 
     @classmethod
-    def compute_parameters(cls, config) -> int:
+    def compute_parameters(cls, config: "ModelConfig") -> int:
         """proj (d_model x 1, no bias) + norm, matching __init__."""
         d = config.d_model
         norm = config.residual_kwargs.get("norm", "rmsnorm")

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Union
 import torch
 import yaml
 
-from src.layers.activation import GATED_ACTIVATIONS, UNGATED_ACTIVATIONS
+from src.layers.activation import ACT_REGISTRY
 from src.layers.attention import ATTN_REGISTRY
 from src.layers.mlp import MLP_REGISTRY, MOE_ROUTER_SCORE_FNS
 from src.layers.pos_emb import POS_EMB_REGISTRY
@@ -168,16 +168,19 @@ class ModelConfig:
     def _set_default_mlp_kwargs(self, mlp_cls: str, kwargs: dict) -> None:
         """Fill defaults/validation for one MLP item's kwargs, keyed on mlp_cls."""
         kwargs.setdefault("intermediate_size", 4 * self.d_model)
-        gated = kwargs.get("gated", True)
-        activation = kwargs.get("activation", "silu")
-        valid = GATED_ACTIVATIONS if gated else UNGATED_ACTIVATIONS
-        if activation not in valid:
+        activation_cls = kwargs.setdefault("activation_cls", "swiglu")
+        if activation_cls not in ACT_REGISTRY:
             raise ValueError(
-                f"Unknown activation: {activation!r}; expected one of {sorted(valid)}"
+                f"Unknown activation: {activation_cls!r}; "
+                f"expected one of {sorted(ACT_REGISTRY)}"
             )
-        act_limit = kwargs.get("activation_limit")
+        activation_kwargs = kwargs.setdefault("activation_kwargs", {})
+        if not isinstance(activation_kwargs, dict):
+            del kwargs["activation_kwargs"]
+            activation_kwargs = {}
+        act_limit = activation_kwargs.get("act_limit")
         if act_limit is not None and not isinstance(act_limit, dict):
-            del kwargs["activation_limit"]
+            del activation_kwargs["act_limit"]
             act_limit = None
         if act_limit is not None:
             for side in ("gate", "up"):
@@ -191,7 +194,7 @@ class ModelConfig:
                     hi = None
                 if lo is not None and hi is not None and lo >= hi:
                     raise ValueError(
-                        f"activation_limit['{side}'] requires min < max; "
+                        f"act_limit['{side}'] requires min < max; "
                         f"got min={lo!r}, max={hi!r}"
                     )
         if mlp_cls == "moe":

--- a/tests/fast/layers/_refs.py
+++ b/tests/fast/layers/_refs.py
@@ -75,15 +75,6 @@ def silu_ref(x: torch.Tensor) -> torch.Tensor:
     return (xf * torch.sigmoid(xf)).to(x.dtype)
 
 
-def silu_openai_ref(x: torch.Tensor) -> torch.Tensor:
-    """OpenAI SiLU: clamp only the positive side before x * sigmoid(alpha * x)."""
-    alpha = 1.702
-    limit = 7.0
-    xf = x.float()
-    gated = xf.clamp(max=limit)
-    return (gated * torch.sigmoid(alpha * gated)).to(x.dtype)
-
-
 def leaky_relu_ref(x: torch.Tensor) -> torch.Tensor:
     """leaky_relu(x, 0.01) = x if x > 0 else 0.01 * x."""
     xf = x.float()
@@ -109,58 +100,50 @@ def leaky_relu2_ref(x: torch.Tensor) -> torch.Tensor:
 # --- Gated (GLU family): (gate, up) → act(gate) * up ---
 
 
-def relu_glu_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+def reglu_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
     return (relu_ref(gate.float()) * up.float()).to(gate.dtype)
 
 
-def gelu_glu_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+def geglu_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
     return (gelu_ref(gate.float()) * up.float()).to(gate.dtype)
 
 
-def silu_glu_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+def swiglu_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
     return (silu_ref(gate.float()) * up.float()).to(gate.dtype)
 
 
-def silu_openai_glu_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
-    alpha = 1.702
-    limit = 7.0
-    gated = gate.float().clamp(max=limit)
-    shifted_up = up.float().clamp(min=-limit, max=limit) + 1.0
-    return (gated * torch.sigmoid(alpha * gated) * shifted_up).to(gate.dtype)
-
-
-def leaky_relu_glu_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+def leaky_reglu_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
     return (leaky_relu_ref(gate.float()) * up.float()).to(gate.dtype)
 
 
-def relu2_glu_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+def reglu2_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
     return ((relu_ref(gate.float()) ** 2) * up.float()).to(gate.dtype)
 
 
-def gelu2_glu_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+def geglu2_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
     return ((gelu_ref(gate.float()) ** 2) * up.float()).to(gate.dtype)
 
 
-def silu2_glu_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+def swiglu2_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
     return ((silu_ref(gate.float()) ** 2) * up.float()).to(gate.dtype)
 
 
-def leaky_relu2_glu_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+def leaky_reglu2_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
     return ((leaky_relu_ref(gate.float()) ** 2) * up.float()).to(gate.dtype)
 
 
 def bilinear_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
-    """Bilinear GLU: gate * up (no unary activation). From Shazeer 2020."""
+    """Bilinear GLU: gate * up (no unary activation_cls). From Shazeer 2020."""
     return (gate.float() * up.float()).to(gate.dtype)
 
 
 def bilinear2_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
-    """Squared Bilinear GLU: gate² * up (squared identity activation on gate)."""
+    """Squared Bilinear GLU: gate² * up (squared identity activation_cls on gate)."""
     return ((gate.float() ** 2) * up.float()).to(gate.dtype)
 
 
 def powlu_ref(x: torch.Tensor) -> torch.Tensor:
-    """PowLU helper (unary part of the gated activation). arXiv:2605.25704, m=3.
+    """PowLU helper (unary part of the gated activation_cls). arXiv:2605.25704, m=3.
     Pos branch: x · x^(m/(sqrt(x)+1)) · sigmoid(x).
     Neg branch: x² · sigmoid(x)  (equals x · silu(x))."""
     m = 3.0
@@ -171,35 +154,44 @@ def powlu_ref(x: torch.Tensor) -> torch.Tensor:
     return torch.where(x > 0, pos, neg)
 
 
-def powlu_glu_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+def powlu_gated_ref(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
     """PowLU GLU: powlu(gate) * up. The gated form from arXiv:2605.25704."""
     return (powlu_ref(gate.float()) * up.float()).to(gate.dtype)
 
 
-UNGATED_ACTIVATIONS_REFS = {
+REFS = {
     "relu": relu_ref,
     "gelu": gelu_ref,
     "silu": silu_ref,
-    "silu_openai": silu_openai_ref,
     "leaky_relu": leaky_relu_ref,
     "relu2": relu2_ref,
     "gelu2": gelu2_ref,
     "silu2": silu2_ref,
     "leaky_relu2": leaky_relu2_ref,
-}
-GATED_ACTIVATIONS_REFS = {
-    "relu": relu_glu_ref,
-    "gelu": gelu_glu_ref,
-    "silu": silu_glu_ref,
-    "silu_openai": silu_openai_glu_ref,
-    "leaky_relu": leaky_relu_glu_ref,
-    "relu2": relu2_glu_ref,
-    "gelu2": gelu2_glu_ref,
-    "silu2": silu2_glu_ref,
-    "leaky_relu2": leaky_relu2_glu_ref,
+    "reglu": reglu_ref,
+    "geglu": geglu_ref,
+    "swiglu": swiglu_ref,
+    "leaky_reglu": leaky_reglu_ref,
+    "reglu2": reglu2_ref,
+    "geglu2": geglu2_ref,
+    "swiglu2": swiglu2_ref,
+    "leaky_reglu2": leaky_reglu2_ref,
     "bilinear": bilinear_ref,
     "bilinear2": bilinear2_ref,
-    "powlu": powlu_glu_ref,
+    "powlu": powlu_gated_ref,
+}
+GATED_ACTIVATIONS_REFS = {
+    "relu": reglu_ref,
+    "gelu": geglu_ref,
+    "silu": swiglu_ref,
+    "leaky_relu": leaky_reglu_ref,
+    "relu2": reglu2_ref,
+    "gelu2": geglu2_ref,
+    "silu2": swiglu2_ref,
+    "leaky_relu2": leaky_reglu2_ref,
+    "bilinear": bilinear_ref,
+    "bilinear2": bilinear2_ref,
+    "powlu": powlu_gated_ref,
 }
 
 
@@ -402,7 +394,7 @@ def mla_ref(
 def dense_mlp_ref(
     x: torch.Tensor,
     down_proj: nn.Linear,
-    activation: str,
+    activation_cls: str,
     up_proj: nn.Linear | None = None,
     gate_up_proj: nn.Linear | None = None,
 ) -> torch.Tensor:
@@ -410,7 +402,7 @@ def dense_mlp_ref(
         ungated (up_proj given):     down_proj(act(up_proj(x)))
         gated   (gate_up_proj given): down_proj(act(gate, up)) where (gate, up) =
                                        chunk(gate_up_proj(x), 2, dim=-1)
-    `activation` is a key in {UN,}GATED_ACTIVATIONS_REFS ("relu"/"gelu"/"silu").
+    `activation_cls` is a key in REFS ("relu"/"gelu"/"swiglu"/...).
     """
     if (up_proj is None) == (gate_up_proj is None):
         raise ValueError(
@@ -418,9 +410,9 @@ def dense_mlp_ref(
         )
     if gate_up_proj is not None:
         gate, up = gate_up_proj(x).chunk(2, dim=-1)
-        hidden = GATED_ACTIVATIONS_REFS[activation](gate, up)
+        hidden = REFS[activation_cls](gate, up)
     else:
-        hidden = UNGATED_ACTIVATIONS_REFS[activation](up_proj(x))
+        hidden = REFS[activation_cls](up_proj(x))
     return down_proj(hidden)
 
 
@@ -454,7 +446,7 @@ def sparse_moe_block_ref(
     gate_weight: torch.Tensor,
     expert_down: torch.Tensor,
     n_routed_experts_per_token: int,
-    activation: str = "silu",
+    activation_cls: str = "swiglu",
     expert_gate_up: torch.Tensor | None = None,
     expert_up: torch.Tensor | None = None,
     normalize: bool = True,
@@ -468,8 +460,9 @@ def sparse_moe_block_ref(
     """Eager sparse MoE: naive per-(token, slot) expert dispatch.
 
     Mirrors MLP's gated/ungated split:
-      - gated   (expert_gate_up given): hidden = act(gate)*up via GATED_ACTIVATIONS_REFS
-      - ungated (expert_up given):      hidden = act(up)      via UNGATED_ACTIVATIONS_REFS
+      - gated   (expert_gate_up given): hidden = act(gate)*up
+      - ungated (expert_up given):      hidden = act(up)
+    both looked up by name in REFS.
     Optional bias tensors are applied per-expert when provided.
 
     LatentMoE (latent_down_weight (ℓ,d) and latent_up_weight (d,ℓ) given): experts run
@@ -506,12 +499,12 @@ def sparse_moe_block_ref(
                 if expert_gate_up_bias is not None:
                     gate_up = gate_up + expert_gate_up_bias[e]
                 g, u = gate_up.chunk(2, dim=-1)
-                hidden = GATED_ACTIVATIONS_REFS[activation](g, u)
+                hidden = REFS[activation_cls](g, u)
             else:
                 up = expert_in[t] @ expert_up[e].T
                 if expert_up_bias is not None:
                     up = up + expert_up_bias[e]
-                hidden = UNGATED_ACTIVATIONS_REFS[activation](up)
+                hidden = REFS[activation_cls](up)
             out_t = hidden @ expert_down[e].T
             if expert_down_bias is not None:
                 out_t = out_t + expert_down_bias[e]

--- a/tests/fast/layers/test_activation.py
+++ b/tests/fast/layers/test_activation.py
@@ -3,17 +3,14 @@
 import pytest
 import torch
 
-from src.layers.activation import GATED_ACTIVATIONS, UNGATED_ACTIVATIONS
-from tests.fast.layers._refs import (
-    GATED_ACTIVATIONS_REFS,
-    SIMPLE_DTYPES,
-    UNGATED_ACTIVATIONS_REFS,
-)
+from src.layers.activation import ACT_REGISTRY
+from tests.fast.layers._refs import REFS, SIMPLE_DTYPES
 
 
 DTYPES = SIMPLE_DTYPES
-ACT_NAMES = list(UNGATED_ACTIVATIONS.keys())
-GATED_ACT_NAMES = list(GATED_ACTIVATIONS.keys())
+# One registry; the entry carries the arity, so the name alone picks gate-vs-unary.
+ACT_NAMES = [n for n, e in ACT_REGISTRY.items() if not e.gated]
+GATED_ACT_NAMES = [n for n, e in ACT_REGISTRY.items() if e.gated]
 # Sub-groups for tests that need different input magnitudes or behavior assumptions.
 SIMPLE_UNGATED = ["relu", "gelu", "silu", "leaky_relu"]
 SQUARED_UNGATED = ["relu2", "gelu2", "silu2", "leaky_relu2"]
@@ -23,13 +20,12 @@ SATURATING_UNGATED = [
     "relu",
     "gelu",
     "silu",
-    "silu_openai",
     "relu2",
     "gelu2",
     "silu2",
 ]
-SIMPLE_GATED = ["relu", "gelu", "silu", "leaky_relu", "bilinear", "powlu"]
-SQUARED_GATED = ["relu2", "gelu2", "silu2", "leaky_relu2", "bilinear2"]
+SIMPLE_GATED = ["reglu", "geglu", "swiglu", "leaky_reglu", "bilinear", "powlu"]
+SQUARED_GATED = ["reglu2", "geglu2", "swiglu2", "leaky_reglu2", "bilinear2"]
 
 
 # ---------------------------- Ungated ----------------------------
@@ -39,8 +35,8 @@ SQUARED_GATED = ["relu2", "gelu2", "silu2", "leaky_relu2", "bilinear2"]
 @pytest.mark.parametrize("dtype,atol", DTYPES)
 def test_ungated_matches_ref(name, dtype, atol):
     """Each ungated activation matches its eager mathematical definition."""
-    act = UNGATED_ACTIVATIONS[name]
-    ref = UNGATED_ACTIVATIONS_REFS[name]
+    act = ACT_REGISTRY[name].fn
+    ref = REFS[name]
     x = torch.randn(2, 16, 64, dtype=dtype)
     out = act(x)
     assert out.dtype == dtype
@@ -55,7 +51,7 @@ def test_ungated_matches_ref(name, dtype, atol):
 @pytest.mark.parametrize("name", ACT_NAMES)
 def test_ungated_zero_input(name):
     """All activations send 0 → 0 (relu: max(0,0); gelu: 0.5*0*(1+0)=0; silu: 0*0.5=0)."""
-    act = UNGATED_ACTIVATIONS[name]
+    act = ACT_REGISTRY[name].fn
     x = torch.zeros(8, 64)
     out = act(x)
     assert torch.isfinite(out).all()
@@ -66,18 +62,8 @@ def test_ungated_zero_input(name):
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_ungated_large_positive_no_overflow_simple(name, dtype):
     """Large positive x: simple unary acts pass through ~unchanged; output must be finite."""
-    act = UNGATED_ACTIVATIONS[name]
-    ref = UNGATED_ACTIVATIONS_REFS[name]
-    x = torch.full((2, 16, 64), 1000.0, dtype=dtype)
-    out = act(x)
-    assert torch.isfinite(out).all()
-    assert torch.allclose(out, ref(x), atol=1.0)
-
-
-@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-def test_ungated_silu_openai_large_positive_clamps(dtype):
-    act = UNGATED_ACTIVATIONS["silu_openai"]
-    ref = UNGATED_ACTIVATIONS_REFS["silu_openai"]
+    act = ACT_REGISTRY[name].fn
+    ref = REFS[name]
     x = torch.full((2, 16, 64), 1000.0, dtype=dtype)
     out = act(x)
     assert torch.isfinite(out).all()
@@ -88,8 +74,8 @@ def test_ungated_silu_openai_large_positive_clamps(dtype):
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_ungated_large_positive_no_overflow_squared(name, dtype):
     """Large positive x for squared variants: 200² = 4e4 fits fp16 (max 65504)."""
-    act = UNGATED_ACTIVATIONS[name]
-    ref = UNGATED_ACTIVATIONS_REFS[name]
+    act = ACT_REGISTRY[name].fn
+    ref = REFS[name]
     x = torch.full((2, 16, 64), 200.0, dtype=dtype)
     out = act(x)
     assert torch.isfinite(out).all()
@@ -101,7 +87,7 @@ def test_ungated_large_positive_no_overflow_squared(name, dtype):
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_ungated_large_negative_saturates(name, dtype):
     """Large negative x: relu/gelu/silu all → ~0; sigmoid/exp must not underflow to nan."""
-    act = UNGATED_ACTIVATIONS[name]
+    act = ACT_REGISTRY[name].fn
     x = torch.full((2, 16, 64), -1000.0, dtype=dtype)
     out = act(x)
     assert torch.isfinite(out).all()
@@ -112,8 +98,8 @@ def test_ungated_large_negative_saturates(name, dtype):
 @pytest.mark.parametrize("dtype,atol", DTYPES)
 def test_ungated_leaky_large_negative(name, dtype, atol):
     """Leaky variants don't saturate on negative; output is bounded but non-zero. Match ref."""
-    act = UNGATED_ACTIVATIONS[name]
-    ref = UNGATED_ACTIVATIONS_REFS[name]
+    act = ACT_REGISTRY[name].fn
+    ref = REFS[name]
     x = torch.full((2, 16, 64), -100.0, dtype=dtype)
     out = act(x)
     assert torch.isfinite(out).all()
@@ -128,7 +114,7 @@ def test_ungated_leaky_large_negative(name, dtype, atol):
 @pytest.mark.parametrize("dtype,atol", DTYPES)
 def test_gated_matches_ref(name, dtype, atol):
     """Each gated activation matches act(gate) * up."""
-    act = GATED_ACTIVATIONS[name]
+    act = ACT_REGISTRY[name].fn
     gate = torch.randn(2, 16, 64, dtype=dtype)
     up = torch.randn(2, 16, 64, dtype=dtype)
     out = act(gate, up)
@@ -144,16 +130,14 @@ def test_gated_matches_ref(name, dtype, atol):
         rtol = 6e-2 if name == "powlu" else (2e-2 if squared else 1e-2)
     else:  # fp16
         rtol = 1e-2 if name == "powlu" else 2e-3
-    assert torch.allclose(
-        out, GATED_ACTIVATIONS_REFS[name](gate, up), atol=atol, rtol=rtol
-    )
+    assert torch.allclose(out, REFS[name](gate, up), atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize("name", SIMPLE_GATED)
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_gated_large_input_no_overflow_simple(name, dtype):
     """Large gate/up for simple gated activations: output finite, matches ref."""
-    act = GATED_ACTIVATIONS[name]
+    act = ACT_REGISTRY[name].fn
     gate = torch.full((2, 16, 64), 100.0, dtype=dtype)
     up = torch.full((2, 16, 64), 100.0, dtype=dtype)
     out = act(gate, up)
@@ -161,39 +145,25 @@ def test_gated_large_input_no_overflow_simple(name, dtype):
     # rtol scales with output magnitude — powlu(100)*100 ≈ 3.5e4, where 1 ULP
     # is ~32 (fp16) / ~256 (bf16), well over the atol tuned for outputs ~1e4.
     rtol = 1e-2 if dtype == torch.bfloat16 else 2e-3
-    assert torch.allclose(
-        out, GATED_ACTIVATIONS_REFS[name](gate, up), atol=10.0, rtol=rtol
-    )
-
-
-@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-def test_gated_silu_openai_large_input_clamps(dtype):
-    act = GATED_ACTIVATIONS["silu_openai"]
-    gate = torch.full((2, 16, 64), 100.0, dtype=dtype)
-    up = torch.full((2, 16, 64), 100.0, dtype=dtype)
-    out = act(gate, up)
-    assert torch.isfinite(out).all()
-    assert torch.allclose(
-        out, GATED_ACTIVATIONS_REFS["silu_openai"](gate, up), atol=1.0, rtol=0.0
-    )
+    assert torch.allclose(out, REFS[name](gate, up), atol=10.0, rtol=rtol)
 
 
 @pytest.mark.parametrize("name", SQUARED_GATED)
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_gated_large_input_no_overflow_squared(name, dtype):
     """Squared gated act: act(20)² · 20 ≈ 8000 fits fp16 (max 65504)."""
-    act = GATED_ACTIVATIONS[name]
+    act = ACT_REGISTRY[name].fn
     gate = torch.full((2, 16, 64), 20.0, dtype=dtype)
     up = torch.full((2, 16, 64), 20.0, dtype=dtype)
     out = act(gate, up)
     assert torch.isfinite(out).all()
-    assert torch.allclose(out, GATED_ACTIVATIONS_REFS[name](gate, up), atol=100.0)
+    assert torch.allclose(out, REFS[name](gate, up), atol=100.0)
 
 
 @pytest.mark.parametrize("name", GATED_ACT_NAMES)
 def test_gated_zero_gate_zeros_output(name):
     """gate=0 → act(0)=0 → output=0 regardless of up."""
-    act = GATED_ACTIVATIONS[name]
+    act = ACT_REGISTRY[name].fn
     gate = torch.zeros(2, 16, 64)
     up = torch.randn(2, 16, 64)
     out = act(gate, up)
@@ -205,9 +175,116 @@ def test_gated_zero_gate_zeros_output(name):
 def test_powlu_negative_gate_saturates(dtype):
     """PowLU's negative branch is x² · sigmoid(x). For gate=-50, sigmoid(-50) ≈ 0
     so output ≈ 0 regardless of up. Important for stability under low-precision."""
-    act = GATED_ACTIVATIONS["powlu"]
+    act = ACT_REGISTRY["powlu"].fn
     gate = torch.full((2, 16, 64), -50.0, dtype=dtype)
     up = torch.full((2, 16, 64), 1.0, dtype=dtype)
     out = act(gate, up)
     assert torch.isfinite(out).all()
     assert out.abs().max().item() < 1e-3
+
+
+# ---------------------------- activation_kwargs axes ----------------------------
+
+# Case lists are independent axes: any activation crosses any limit/shift/alpha.
+UNGATED_LIMITS = [
+    {"up": {"max": 1.0}},
+    {"up": {"min": -1.0}},
+    {"up": {"min": -1.0, "max": 1.0}},
+]
+GATED_LIMITS = [
+    {"gate": {"max": 1.0}},
+    {"up": {"min": -1.0, "max": 1.0}},
+    {"gate": {"max": 7.0}, "up": {"min": -7.0, "max": 7.0}},
+]
+UP_SHIFTS = [1.0, -0.5]
+ALPHAS = [1.702, 0.5]
+ALPHA_ACTS = ["silu", "silu2", "swiglu", "swiglu2"]
+# Already floored at 0 on the negative side, so a min-only bound cannot bite.
+FLOORED_UNGATED = ["relu", "relu2"]
+SLOPE_ACTS = ["leaky_relu", "leaky_relu2"]
+
+
+def _spread(*shape, dtype=torch.float32, seed=0):
+    """Inputs wide enough that every limit in the case lists actually bites."""
+    torch.manual_seed(seed)
+    return torch.randn(*shape, dtype=dtype) * 5.0
+
+
+@pytest.mark.parametrize("name", ACT_NAMES)
+@pytest.mark.parametrize("act_limit", UNGATED_LIMITS)
+def test_ungated_act_limit(name, act_limit):
+    """act_limit clamps the input before the activation, and actually bites."""
+    if name in FLOORED_UNGATED and set(act_limit["up"]) == {"min"}:
+        pytest.skip(f"{name} floors negatives at 0; a min-only bound is a no-op")
+    act = ACT_REGISTRY[name].fn
+    x = _spread(2, 16, 64)
+    # same ops on both sides -> bit-identical, so exact comparison
+    assert torch.equal(act(x, act_limit=act_limit), act(x.clamp(**act_limit["up"])))
+    assert not torch.equal(act(x, act_limit=act_limit), act(x))
+    assert torch.equal(act(x, act_limit=None), act(x))
+
+
+@pytest.mark.parametrize("name", GATED_ACT_NAMES)
+@pytest.mark.parametrize("act_limit", GATED_LIMITS)
+def test_gated_act_limit(name, act_limit):
+    """Gated act_limit clamps each side independently, pre-activation."""
+    act = ACT_REGISTRY[name].fn
+    gate, up = _spread(2, 16, 64, seed=1), _spread(2, 16, 64, seed=2)
+    g = gate.clamp(**act_limit["gate"]) if "gate" in act_limit else gate
+    u = up.clamp(**act_limit["up"]) if "up" in act_limit else up
+    assert torch.equal(act(gate, up, act_limit=act_limit), act(g, u))
+    assert not torch.equal(act(gate, up, act_limit=act_limit), act(gate, up))
+
+
+@pytest.mark.parametrize("name", GATED_ACT_NAMES)
+@pytest.mark.parametrize("up_shift", UP_SHIFTS)
+def test_gated_up_shift(name, up_shift):
+    """up_shift offsets the up branch; the default 0.0 stays bit-identical."""
+    act = ACT_REGISTRY[name].fn
+    gate, up = _spread(2, 16, 64, seed=1), _spread(2, 16, 64, seed=2)
+    assert torch.equal(act(gate, up, up_shift=up_shift), act(gate, up + up_shift))
+    assert torch.equal(act(gate, up, up_shift=0.0), act(gate, up))
+
+
+@pytest.mark.parametrize("name", ALPHA_ACTS)
+@pytest.mark.parametrize("alpha", ALPHAS)
+def test_silu_alpha(name, alpha):
+    """alpha scales only the sigmoid argument; alpha=1.0 stays bit-identical."""
+    x = _spread(2, 16, 64)
+    act, gated = ACT_REGISTRY[name]
+    args = (x, x) if gated else (x,)
+    assert torch.equal(act(*args, alpha=1.0), act(*args))
+    assert not torch.equal(act(*args, alpha=alpha), act(*args))
+
+
+@pytest.mark.parametrize("alpha", [1.0, *ALPHAS])
+@pytest.mark.parametrize("dtype,atol", DTYPES)
+def test_silu_alpha_precision(alpha, dtype, atol):
+    """silu(x, alpha) == x * sigmoid(alpha*x), including the alpha=1 F.silu path."""
+    x = torch.randn(2, 16, 64, dtype=dtype)
+    xf = x.float()
+    ref = (xf * torch.sigmoid(alpha * xf)).to(dtype)
+    out = ACT_REGISTRY["silu"].fn(x, alpha=alpha)
+    assert out.dtype == dtype
+    assert torch.allclose(out, ref, atol=atol, rtol=0.0)
+
+
+@pytest.mark.parametrize("name", SLOPE_ACTS)
+@pytest.mark.parametrize("negative_slope", [0.2, 0.0])
+def test_leaky_relu_negative_slope(name, negative_slope):
+    """negative_slope is configurable; the 0.01 default stays bit-identical."""
+    x = _spread(2, 16, 64)
+    act = ACT_REGISTRY[name].fn
+    squared = 2 if name.endswith("2") else 1
+    ref = torch.where(x > 0, x, negative_slope * x) ** squared
+    assert torch.allclose(act(x, negative_slope=negative_slope), ref, atol=1e-6, rtol=0)
+    assert torch.equal(act(x, negative_slope=0.01), act(x))
+
+
+@pytest.mark.parametrize("m", [2.0, 4.0])
+def test_powlu_m(m):
+    """powlu's exponent m is configurable; the 3.0 default stays bit-identical."""
+    act = ACT_REGISTRY["powlu"].fn
+    gate, up = _spread(2, 16, 64, seed=1), _spread(2, 16, 64, seed=2)
+    assert torch.equal(act(gate, up, m=3.0), act(gate, up))
+    assert not torch.equal(act(gate, up, m=m), act(gate, up))

--- a/tests/fast/layers/test_block.py
+++ b/tests/fast/layers/test_block.py
@@ -24,7 +24,7 @@ def _block_cfg(impl):
         mlp=[
             {
                 "mlp_cls": "dense",
-                "mlp_kwargs": {"activation": "gelu", "gated": False, "bias": True},
+                "mlp_kwargs": {"activation_cls": "gelu", "bias": True},
             }
         ],
         norm_cls="layernorm",

--- a/tests/fast/layers/test_mlp.py
+++ b/tests/fast/layers/test_mlp.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 from src.kernel.ops.gemm import grouped_mm
-from src.layers.activation import GATED_ACTIVATIONS, UNGATED_ACTIVATIONS
+from src.layers.activation import ACT_REGISTRY
 from src.layers.mlp import (
     DenseMLPBlock,
     ExpertBias,
@@ -29,8 +29,10 @@ def grouped_mm_eager(a, b, offs, bias=None):
     return grouped_mm(a, b, offs, bias=bias, backend="eager")
 
 
-ACT_NAMES = list(UNGATED_ACTIVATIONS.keys())
-GATED_ACT_NAMES = list(GATED_ACTIVATIONS.keys())
+ACT_NAMES = [n for n, e in ACT_REGISTRY.items() if not e.gated]
+GATED_ACT_NAMES = [n for n, e in ACT_REGISTRY.items() if e.gated]
+# One unary / one gated name, for tests that only need to cross the arity split.
+ARITY_PAIR = ["silu", "swiglu"]
 
 
 # ---------------------------------------------------------------------------
@@ -48,10 +50,13 @@ def test_mlp_registry():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("gated", [False, True])
-def test_dense_output_shape(gated):
+@pytest.mark.parametrize("activation_cls", ARITY_PAIR)
+def test_dense_output_shape(activation_cls):
     blk = DenseMLPBlock(
-        d_model=64, intermediate_size=128, activation="silu", gated=gated, dropout=0.0
+        d_model=64,
+        intermediate_size=128,
+        activation_cls=activation_cls,
+        dropout=0.0,
     )
     x = torch.randn(2, 16, 64)
     out, aux = blk(x)
@@ -59,29 +64,27 @@ def test_dense_output_shape(gated):
 
 
 def test_dense_returns_none_aux():
-    blk = DenseMLPBlock(
-        d_model=64, intermediate_size=128, activation="silu", gated=True
-    )
+    blk = DenseMLPBlock(d_model=64, intermediate_size=128, activation_cls="swiglu")
     out, aux = blk(torch.randn(2, 8, 64))
     assert out.shape == (2, 8, 64) and aux is None
 
 
-@pytest.mark.parametrize("gated", [False, True])
-def test_dense_default_bias_is_false(gated):
+@pytest.mark.parametrize("activation_cls", ARITY_PAIR)
+def test_dense_default_bias_is_false(activation_cls):
     blk = DenseMLPBlock(
-        d_model=64, intermediate_size=128, activation="silu", gated=gated
+        d_model=64, intermediate_size=128, activation_cls=activation_cls
     )
-    w1 = blk.gate_up_proj if gated else blk.up_proj
+    w1 = blk.gate_up_proj if blk.gated else blk.up_proj
     assert w1.bias is None
     assert blk.down_proj.bias is None
 
 
-@pytest.mark.parametrize("gated", [False, True])
-def test_dense_bias_true_adds_biases(gated):
+@pytest.mark.parametrize("activation_cls", ARITY_PAIR)
+def test_dense_bias_true_adds_biases(activation_cls):
     blk = DenseMLPBlock(
-        d_model=64, intermediate_size=128, activation="silu", gated=gated, bias=True
+        d_model=64, intermediate_size=128, activation_cls=activation_cls, bias=True
     )
-    w1 = blk.gate_up_proj if gated else blk.up_proj
+    w1 = blk.gate_up_proj if blk.gated else blk.up_proj
     assert w1.bias is not None
     assert blk.down_proj.bias is not None
 
@@ -100,19 +103,31 @@ ACT_LIMIT_BLOCKS = [
 ]
 
 
-@pytest.mark.parametrize("gated", [False, True])
+# Loose bounds no side of the data ever reaches; tight ones it always does.
+LOOSE_LIMITS = {
+    True: {"gate": {"max": 1e6}, "up": {"min": -1e6, "max": 1e6}},
+    False: {"up": {"min": -1e6, "max": 1e6}},
+}
+TIGHT_LIMITS = {
+    True: {"gate": {"max": 1.0}, "up": {"min": -1.0, "max": 1.0}},
+    False: {"up": {"min": -1.0, "max": 1.0}},
+}
+
+
+@pytest.mark.parametrize("activation_cls", ARITY_PAIR)
 @pytest.mark.parametrize("block_cls,extra", ACT_LIMIT_BLOCKS)
-def test_activation_limit(block_cls, extra, gated):
+def test_act_limit(block_cls, extra, activation_cls):
     """A limit above the data is a no-op; a tight one bounds the pre-activation."""
     torch.manual_seed(0)
-    common = dict(d_model=64, intermediate_size=128, gated=gated, **extra)
+    gated = ACT_REGISTRY[activation_cls].gated
+    common = dict(
+        d_model=64, intermediate_size=128, activation_cls=activation_cls, **extra
+    )
     # x is scaled so the projection output reliably exceeds the tight limit
     x = torch.randn(2, 16, 64) * 8
-    loose_lim = {"gate": {"max": 1e6}, "up": {"min": -1e6, "max": 1e6}}
-    tight_lim = {"gate": {"max": 1.0}, "up": {"min": -1.0, "max": 1.0}}
     unbounded = block_cls(**common)
-    loose = block_cls(**common, activation_limit=loose_lim)
-    tight = block_cls(**common, activation_limit=tight_lim)
+    loose = block_cls(**common, activation_kwargs={"act_limit": LOOSE_LIMITS[gated]})
+    tight = block_cls(**common, activation_kwargs={"act_limit": TIGHT_LIMITS[gated]})
     loose.load_state_dict(unbounded.state_dict())
     tight.load_state_dict(unbounded.state_dict())
 
@@ -125,22 +140,32 @@ def test_activation_limit(block_cls, extra, gated):
     assert not torch.allclose(base, out)
 
 
-@pytest.mark.parametrize("gated", [False, True])
-def test_dense_activation_limit_precision(gated):
-    """Clamping the projection output reproduces the block's forward exactly."""
+@pytest.mark.parametrize("activation_cls", ARITY_PAIR)
+def test_dense_activation_kwargs_precision(activation_cls):
+    """The block's forward equals the raw activation applied to clamped, shifted
+    projections -- i.e. activation_kwargs reach the activation intact."""
     torch.manual_seed(0)
-    limit = {"gate": {"max": 1.0}, "up": {"min": -1.0, "max": 1.0}}
+    gated = ACT_REGISTRY[activation_cls].gated
+    act_kwargs = {"alpha": 1.702, "act_limit": TIGHT_LIMITS[gated]}
+    if gated:
+        act_kwargs["up_shift"] = 1.0
     blk = DenseMLPBlock(
-        d_model=64, intermediate_size=128, gated=gated, activation_limit=limit
+        d_model=64,
+        intermediate_size=128,
+        activation_cls=activation_cls,
+        activation_kwargs=act_kwargs,
     )
     x = torch.randn(2, 16, 64) * 8
+    # the unbound registry entry, so the reference clamps and shifts explicitly
     if gated:
+        act = ACT_REGISTRY["swiglu"].fn
         gate, up = blk.gate_up_proj(x).chunk(2, dim=-1)
         # gate clamped above only, up clamped symmetrically (DeepSeek-V4)
-        hidden = blk.act_fn(gate.clamp(max=1.0), up.clamp(-1.0, 1.0))
+        gate, up = gate.clamp(max=1.0), up.clamp(-1.0, 1.0) + 1.0
+        hidden = act(gate, up, alpha=1.702)
     else:
-        # ungated: single tensor clamped with the "up" bounds
-        hidden = blk.act_fn(blk.up_proj(x).clamp(-1.0, 1.0))
+        act = ACT_REGISTRY["silu"].fn
+        hidden = act(blk.up_proj(x).clamp(-1.0, 1.0), alpha=1.702)
     ref = blk.down_proj(hidden)
     # same ops in the same order, so the match is exact
     assert torch.equal(blk(x)[0], ref)
@@ -152,17 +177,23 @@ def test_dense_activation_limit_precision(gated):
 
 
 def test_dense_compute_flops_gated():
-    f = DenseMLPBlock.compute_flops(64, intermediate_size=128, gated=True, bias=False)
+    f = DenseMLPBlock.compute_flops(
+        64, intermediate_size=128, activation_cls="swiglu", bias=False
+    )
     assert f == 6 * 64 * 128
 
 
 def test_dense_compute_flops_ungated():
-    f = DenseMLPBlock.compute_flops(64, intermediate_size=128, gated=False, bias=False)
+    f = DenseMLPBlock.compute_flops(
+        64, intermediate_size=128, activation_cls="silu", bias=False
+    )
     assert f == 4 * 64 * 128
 
 
 def test_dense_compute_flops_gated_bias():
-    f = DenseMLPBlock.compute_flops(64, intermediate_size=128, gated=True, bias=True)
+    f = DenseMLPBlock.compute_flops(
+        64, intermediate_size=128, activation_cls="swiglu", bias=True
+    )
     assert f == 6 * 64 * 128 + 2 * 128 + 64
 
 
@@ -171,43 +202,41 @@ def test_dense_compute_flops_gated_bias():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("activation", ACT_NAMES)
+@pytest.mark.parametrize("activation_cls", ACT_NAMES)
 @pytest.mark.parametrize("dtype,atol", SIMPLE_DTYPES)
-def test_dense_ungated_matches_ref(activation, dtype, atol):
+def test_dense_ungated_matches_ref(activation_cls, dtype, atol):
     torch.manual_seed(0)
     blk = DenseMLPBlock(
         d_model=64,
         intermediate_size=256,
-        activation=activation,
-        gated=False,
+        activation_cls=activation_cls,
         dropout=0.0,
     ).to(dtype)
     blk.eval()
     x = torch.randn(2, 16, 64, dtype=dtype)
     out, _ = blk(x)
     out_ref = dense_mlp_ref(
-        x, blk.down_proj, activation=activation, up_proj=blk.up_proj
+        x, blk.down_proj, activation_cls=activation_cls, up_proj=blk.up_proj
     )
     assert out.dtype == dtype
     assert torch.allclose(out, out_ref, atol=atol)
 
 
-@pytest.mark.parametrize("activation", GATED_ACT_NAMES)
+@pytest.mark.parametrize("activation_cls", GATED_ACT_NAMES)
 @pytest.mark.parametrize("dtype,atol", SIMPLE_DTYPES)
-def test_dense_gated_matches_ref(activation, dtype, atol):
+def test_dense_gated_matches_ref(activation_cls, dtype, atol):
     torch.manual_seed(0)
     blk = DenseMLPBlock(
         d_model=64,
         intermediate_size=128,
-        activation=activation,
-        gated=True,
+        activation_cls=activation_cls,
         dropout=0.0,
     ).to(dtype)
     blk.eval()
     x = torch.randn(2, 16, 64, dtype=dtype)
     out, _ = blk(x)
     out_ref = dense_mlp_ref(
-        x, blk.down_proj, activation=activation, gate_up_proj=blk.gate_up_proj
+        x, blk.down_proj, activation_cls=activation_cls, gate_up_proj=blk.gate_up_proj
     )
     assert out.dtype == dtype
     assert torch.allclose(out, out_ref, atol=atol)
@@ -692,8 +721,8 @@ def test_sparse_moe_no_shared_experts_by_default():
 
 
 @pytest.mark.parametrize("n_shared_experts", [1, 2])
-@pytest.mark.parametrize("gated", [True, False])
-def test_sparse_moe_shared_expert_width_and_shape(n_shared_experts, gated):
+@pytest.mark.parametrize("activation_cls", ARITY_PAIR)
+def test_sparse_moe_shared_expert_width_and_shape(n_shared_experts, activation_cls):
     inter = 128
     block = SparseMoEBlock(
         d_model=64,
@@ -701,8 +730,9 @@ def test_sparse_moe_shared_expert_width_and_shape(n_shared_experts, gated):
         n_routed_experts=4,
         n_routed_experts_per_token=2,
         n_shared_experts=n_shared_experts,
-        gated=gated,
+        activation_cls=activation_cls,
     )
+    gated = ACT_REGISTRY[activation_cls].gated
     assert block.shared_expert is not None
     w1 = block.shared_expert.gate_up_proj if gated else block.shared_expert.up_proj
     expected = (2 if gated else 1) * n_shared_experts * inter
@@ -737,11 +767,13 @@ def test_sparse_moe_shared_expert_in_param_count():
         intermediate_size=128,
         n_routed_experts=4,
         n_routed_experts_per_token=2,
-        gated=True,
+        activation_cls="swiglu",
     )
     base = SparseMoEBlock.compute_parameters(64, **kwargs)
     with_shared = SparseMoEBlock.compute_parameters(64, n_shared_experts=2, **kwargs)
-    dense = DenseMLPBlock.compute_parameters(64, intermediate_size=2 * 128, gated=True)
+    dense = DenseMLPBlock.compute_parameters(
+        64, intermediate_size=2 * 128, activation_cls="swiglu"
+    )
     assert with_shared - base == dense
     # Shared experts count in active params too (always run).
     base_active = SparseMoEBlock.compute_parameters(64, active=True, **kwargs)
@@ -756,11 +788,13 @@ def test_sparse_moe_shared_expert_in_flops():
         intermediate_size=128,
         n_routed_experts=4,
         n_routed_experts_per_token=2,
-        gated=True,
+        activation_cls="swiglu",
     )
     base = SparseMoEBlock.compute_flops(64, **kwargs)
     with_shared = SparseMoEBlock.compute_flops(64, n_shared_experts=2, **kwargs)
-    dense = DenseMLPBlock.compute_flops(64, intermediate_size=2 * 128, gated=True)
+    dense = DenseMLPBlock.compute_flops(
+        64, intermediate_size=2 * 128, activation_cls="swiglu"
+    )
     assert with_shared - base == dense
 
 
@@ -775,7 +809,7 @@ def test_sparse_moe_compute_flops_gated():
         intermediate_size=128,
         n_routed_experts=4,
         n_routed_experts_per_token=2,
-        gated=True,
+        activation_cls="swiglu",
         bias=False,
     )
     router = 2 * 64 * 4
@@ -789,7 +823,7 @@ def test_sparse_moe_compute_flops_ungated():
         intermediate_size=128,
         n_routed_experts=4,
         n_routed_experts_per_token=2,
-        gated=False,
+        activation_cls="silu",
         bias=False,
     )
     router = 2 * 64 * 4
@@ -802,7 +836,7 @@ def test_sparse_moe_compute_flops_expert_bias():
         intermediate_size=128,
         n_routed_experts=4,
         n_routed_experts_per_token=2,
-        gated=True,
+        activation_cls="swiglu",
     )
     base = SparseMoEBlock.compute_flops(64, **kwargs)
     with_bias = SparseMoEBlock.compute_flops(64, expert_bias=True, **kwargs)
@@ -814,7 +848,7 @@ def test_sparse_moe_compute_parameters_expert_bias():
         intermediate_size=128,
         n_routed_experts=4,
         n_routed_experts_per_token=2,
-        gated=True,
+        activation_cls="swiglu",
     )
     base = SparseMoEBlock.compute_parameters(64, **kwargs)
     with_bias = SparseMoEBlock.compute_parameters(64, expert_bias=True, **kwargs)
@@ -836,7 +870,7 @@ def test_sparse_moe_compute_parameters_expert_bias_matches_live_module():
         intermediate_size=128,
         n_routed_experts=4,
         n_routed_experts_per_token=2,
-        gated=True,
+        activation_cls="swiglu",
         expert_bias=True,
         aux_loss=False,
     )
@@ -894,18 +928,13 @@ def test_moe_router_matches_ref_under_saturation(dtype, atol):
 
 
 @pytest.mark.parametrize(
-    "gated,activation",
-    [
-        (True, "silu"),
-        (True, "silu_openai"),
-        (False, "gelu"),
-        (False, "silu_openai"),
-        (False, "relu"),
-    ],
+    "activation_cls",
+    ["swiglu", "swiglu2", "gelu", "silu2", "relu"],
 )
 @pytest.mark.parametrize("dtype,atol", COMPOUND_DTYPES)
-def test_sparse_moe_block_matches_ref(gated, activation, dtype, atol):
+def test_sparse_moe_block_matches_ref(activation_cls, dtype, atol):
     torch.manual_seed(0)
+    gated = ACT_REGISTRY[activation_cls].gated
     d_model, inter, n_routed_experts, k = 64, 32, 4, 2
     block = SparseMoEBlock(
         d_model=d_model,
@@ -913,8 +942,7 @@ def test_sparse_moe_block_matches_ref(gated, activation, dtype, atol):
         n_routed_experts=n_routed_experts,
         n_routed_experts_per_token=k,
         dropout=0.0,
-        gated=gated,
-        activation=activation,
+        activation_cls=activation_cls,
         router_score_fn="softmax",
         aux_loss_coef=1.0,  # ref returns unscaled aux; coef=1.0 keeps parity
     )
@@ -932,7 +960,7 @@ def test_sparse_moe_block_matches_ref(gated, activation, dtype, atol):
         block.router.gate.weight,
         block.expert_down,
         n_routed_experts_per_token=k,
-        activation=activation,
+        activation_cls=activation_cls,
         normalize=True,
         expert_gate_up=block.expert_gate_up if gated else None,
         expert_up=None if gated else block.expert_up,
@@ -996,18 +1024,18 @@ def test_sparse_moe_block_matches_hf_qwen3_moe():
 # counts cover an empty group in interior, leading, and trailing positions.
 @pytest.mark.parametrize("counts", [[5, 0, 7, 4], [0, 5, 7, 4], [5, 7, 4, 0]])
 @pytest.mark.parametrize(
-    "gated,activation",
-    [(True, "silu"), (True, "silu_openai"), (False, "gelu"), (False, "silu_openai")],
+    "activation_cls",
+    ["swiglu", "swiglu2", "gelu", "silu2"],
 )
 @pytest.mark.parametrize("use_bias", [False, True])
 @pytest.mark.parametrize("dtype,atol", COMPOUND_DTYPES)
 def test_grouped_mlp_matches_per_group_loop(
-    gated, activation, use_bias, dtype, atol, counts
+    activation_cls, use_bias, dtype, atol, counts
 ):
     torch.manual_seed(0)
     E, D, inter = 4, 16, 32
     R = sum(counts)
-    act = (GATED_ACTIVATIONS if gated else UNGATED_ACTIVATIONS)[activation]
+    act, gated = ACT_REGISTRY[activation_cls]
 
     x = torch.randn(R, D, dtype=dtype)
     out_dim = 2 * inter if gated else inter
@@ -1054,13 +1082,13 @@ def test_grouped_mlp_matches_per_group_loop(
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="grouped_mm compile is CUDA+bf16 only"
 )
-@pytest.mark.parametrize("gated,activation", [(True, "silu"), (False, "gelu")])
-def test_grouped_mlp_compiled_matches_eager_cuda_bf16(gated, activation):
+@pytest.mark.parametrize("activation_cls", ["swiglu", "gelu"])
+def test_grouped_mlp_compiled_matches_eager_cuda_bf16(activation_cls):
     torch.manual_seed(0)
     E, D, inter = 4, 16, 32
     counts = [5, 0, 7, 4]  # includes an empty group
     R = sum(counts)
-    act = (GATED_ACTIVATIONS if gated else UNGATED_ACTIVATIONS)[activation]
+    act, gated = ACT_REGISTRY[activation_cls]
     x = torch.randn(R, D, device="cuda", dtype=torch.bfloat16)
     out_dim = 2 * inter if gated else inter
     w_in = torch.randn(E, out_dim, D, device="cuda", dtype=torch.bfloat16) * 0.1
@@ -1072,17 +1100,17 @@ def test_grouped_mlp_compiled_matches_eager_cuda_bf16(gated, activation):
     assert torch.allclose(compiled, eager, atol=1e-2)
 
 
-@pytest.mark.parametrize("gated", [True, False])
-def test_sparse_moe_dropless_handles_empty_expert_and_bias(gated):
+@pytest.mark.parametrize("activation_cls", ["swiglu", "gelu"])
+def test_sparse_moe_dropless_handles_empty_expert_and_bias(activation_cls):
     torch.manual_seed(0)
+    gated = ACT_REGISTRY[activation_cls].gated
     d_model, inter, E, k = 32, 16, 4, 2
     block = SparseMoEBlock(
         d_model=d_model,
         intermediate_size=inter,
         n_routed_experts=E,
         n_routed_experts_per_token=k,
-        gated=gated,
-        activation="silu" if gated else "gelu",
+        activation_cls=activation_cls,
         bias=True,
         router_score_fn="softmax",
         aux_loss_coef=1.0,  # ref returns unscaled aux; coef=1.0 keeps parity
@@ -1109,7 +1137,7 @@ def test_sparse_moe_dropless_handles_empty_expert_and_bias(gated):
         block.router.gate.weight,
         block.expert_down,
         n_routed_experts_per_token=k,
-        activation="silu" if gated else "gelu",
+        activation_cls=activation_cls,
         normalize=True,
         expert_gate_up=block.expert_gate_up if gated else None,
         expert_up=None if gated else block.expert_up,
@@ -1128,7 +1156,7 @@ def test_grouped_mlp_casts_to_autocast_dtype():
     E, D, inter = 4, 16, 32
     counts = [5, 0, 7, 4]
     R = sum(counts)
-    act = GATED_ACTIVATIONS["silu"]
+    act = ACT_REGISTRY["swiglu"].fn
     x = torch.randn(R, D, device="cpu")  # fp32 on CPU
     w_in = torch.randn(E, 2 * inter, D, device="cpu") * 0.1  # fp32 on CPU
     w_down = torch.randn(E, D, inter, device="cpu") * 0.1  # fp32 on CPU
@@ -1193,12 +1221,13 @@ def test_sparse_moe_latent_output_shape():
 
 @pytest.mark.parametrize("bias", [False, True])
 @pytest.mark.parametrize(
-    "gated,activation",
-    [(True, "silu"), (True, "silu_openai"), (False, "gelu"), (False, "silu_openai")],
+    "activation_cls",
+    ["swiglu", "swiglu2", "gelu", "silu2"],
 )
 @pytest.mark.parametrize("dtype,atol", COMPOUND_DTYPES)
-def test_sparse_moe_latent_matches_ref(gated, activation, dtype, atol, bias):
+def test_sparse_moe_latent_matches_ref(activation_cls, dtype, atol, bias):
     torch.manual_seed(0)
+    gated = ACT_REGISTRY[activation_cls].gated
     d_model, inter, E, k, ell = 64, 32, 4, 2, 16
     aux_loss_coef = 0.05
     block = SparseMoEBlock(
@@ -1207,8 +1236,7 @@ def test_sparse_moe_latent_matches_ref(gated, activation, dtype, atol, bias):
         n_routed_experts=E,
         n_routed_experts_per_token=k,
         dropout=0.0,
-        gated=gated,
-        activation=activation,
+        activation_cls=activation_cls,
         router_score_fn="softmax",
         aux_loss_coef=aux_loss_coef,
         bias=bias,
@@ -1235,7 +1263,7 @@ def test_sparse_moe_latent_matches_ref(gated, activation, dtype, atol, bias):
         block.router.gate.weight,
         block.expert_down,
         n_routed_experts_per_token=k,
-        activation=activation,
+        activation_cls=activation_cls,
         normalize=True,
         expert_gate_up=block.expert_gate_up if gated else None,
         expert_up=None if gated else block.expert_up,
@@ -1266,8 +1294,7 @@ def test_sparse_moe_latent_with_shared_experts_matches_ref_plus_shared():
         n_routed_experts_per_token=k,
         n_shared_experts=1,
         dropout=0.0,
-        gated=True,
-        activation="silu",
+        activation_cls="swiglu",
         router_score_fn="softmax",
         aux_loss_coef=aux_loss_coef,
         latent_moe=True,
@@ -1288,7 +1315,7 @@ def test_sparse_moe_latent_with_shared_experts_matches_ref_plus_shared():
         block.router.gate.weight,
         block.expert_down,
         n_routed_experts_per_token=k,
-        activation="silu",
+        activation_cls="swiglu",
         normalize=True,
         expert_gate_up=block.expert_gate_up,
         latent_down_weight=block.latent_down_proj.weight,
@@ -1359,9 +1386,9 @@ def test_sparse_moe_latent_flops_less_than_dense_moe():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="grouped GEMM is CUDA only")
-@pytest.mark.parametrize("gated", [True, False])
+@pytest.mark.parametrize("activation_cls", ["swiglu", "gelu"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
-def test_sparse_moe_block_compiles_fullgraph(gated, dtype):
+def test_sparse_moe_block_compiles_fullgraph(activation_cls, dtype):
     torch.manual_seed(0)
     blk = (
         SparseMoEBlock(
@@ -1369,8 +1396,7 @@ def test_sparse_moe_block_compiles_fullgraph(gated, dtype):
             intermediate_size=32,
             n_routed_experts=4,
             n_routed_experts_per_token=2,
-            gated=gated,
-            activation="silu" if gated else "gelu",
+            activation_cls=activation_cls,
             router_score_fn="softmax",
             aux_loss=False,
             expert_bias=True,

--- a/tests/fast/metrics/test_collector.py
+++ b/tests/fast/metrics/test_collector.py
@@ -46,7 +46,10 @@ def _cfg(task="pretrain", log_every=2, **logging):
             mlp=[
                 {
                     "mlp_cls": "dense",
-                    "mlp_kwargs": {"gated": False, "bias": True, "activation": "gelu"},
+                    "mlp_kwargs": {
+                        "bias": True,
+                        "activation_cls": "gelu",
+                    },
                 }
             ],
         )
@@ -830,7 +833,7 @@ def test_print_model_summary_moe(capsys):
 
 
 # ---------------------------------------------------------------------------
-# val-side activation / quantization windows
+# val-side activation_cls / quantization windows
 # ---------------------------------------------------------------------------
 
 
@@ -948,7 +951,7 @@ def test_log_eval_without_a_model_emits_no_window_keys():
 
 
 # ---------------------------------------------------------------------------
-# train-side activation window: train_step_begin arms it, log_train reads it
+# train-side activation_cls window: train_step_begin arms it, log_train reads it
 # ---------------------------------------------------------------------------
 
 

--- a/tests/fast/metrics/test_convert.py
+++ b/tests/fast/metrics/test_convert.py
@@ -34,7 +34,14 @@ def _block_cfg(n_layers=1):
                 "attn_kwargs": {"n_heads": 4, "attn_implementation": "sdpa"},
             }
         ],
-        mlp=[{"mlp_cls": "dense", "mlp_kwargs": {"activation": "silu", "gated": True}}],
+        mlp=[
+            {
+                "mlp_cls": "dense",
+                "mlp_kwargs": {
+                    "activation_cls": "swiglu",
+                },
+            }
+        ],
         norm_cls="rmsnorm",
         pos_emb_cls="rope",
         pos_emb_kwargs={},
@@ -69,8 +76,8 @@ def test_sites_are_exactly_the_linear_inputs():
 
 
 def test_embedding_is_not_a_site_but_tied_lm_head_is():
-    """torch.nn.Embedding consumes token ids, not an activation; the tied lm_head still
-    contracts a real activation against the same weight."""
+    """torch.nn.Embedding consumes token ids, not an activation_cls; the tied lm_head still
+    contracts a real activation_cls against the same weight."""
     model = torch.nn.Module()
     model.token_emb = torch.nn.Embedding(32, D_MODEL)
     model.lm_head = torch.nn.Linear(D_MODEL, 32, bias=False)

--- a/tests/fast/metrics/test_functional.py
+++ b/tests/fast/metrics/test_functional.py
@@ -37,7 +37,7 @@ def _gpt2_cfg(impl):
         mlp=[
             {
                 "mlp_cls": "dense",
-                "mlp_kwargs": {"gated": False, "bias": True, "activation": "gelu"},
+                "mlp_kwargs": {"bias": True, "activation_cls": "gelu"},
             }
         ],
     )
@@ -108,7 +108,7 @@ def _gpt2_attn_res_cfg(impl):
         mlp=[
             {
                 "mlp_cls": "dense",
-                "mlp_kwargs": {"gated": False, "bias": True, "activation": "gelu"},
+                "mlp_kwargs": {"bias": True, "activation_cls": "gelu"},
             }
         ],
         residual_cls="attn_res",
@@ -691,7 +691,7 @@ def _gpt2_layernorm_learned_cfg(impl):
         mlp=[
             {
                 "mlp_cls": "dense",
-                "mlp_kwargs": {"gated": False, "bias": True, "activation": "gelu"},
+                "mlp_kwargs": {"bias": True, "activation_cls": "gelu"},
             }
         ],
         norm_cls="layernorm",
@@ -799,8 +799,7 @@ def test_compute_flops_per_token_dense_gpt2_mha_ungated():
                 "mlp_cls": "dense",
                 "mlp_kwargs": {
                     "intermediate_size": 256,
-                    "activation": "gelu",
-                    "gated": False,
+                    "activation_cls": "gelu",
                     "bias": True,
                 },
             }
@@ -838,8 +837,7 @@ def test_compute_flops_per_token_gqa_gated_qwen3():
                 "mlp_cls": "dense",
                 "mlp_kwargs": {
                     "intermediate_size": 256,
-                    "activation": "silu",
-                    "gated": True,
+                    "activation_cls": "swiglu",
                     "bias": False,
                 },
             }
@@ -872,7 +870,7 @@ def test_compute_flops_per_token_moe_uses_k_active():
                     "aux_loss_coef": 1e-3,
                     "n_routed_experts_per_token": 2,
                     "intermediate_size": 128,
-                    "gated": True,
+                    "activation_cls": "swiglu",
                     "bias": False,
                 },
             }

--- a/tests/fast/model/test_transformer.py
+++ b/tests/fast/model/test_transformer.py
@@ -15,7 +15,14 @@ def _cfg(max_seq_len=32, **model_over):
         n_layers=2,
         vocab_size=256,
         attn=[{"attn_cls": "gqa", "attn_kwargs": {"n_heads": 4, "n_kv_heads": 2}}],
-        mlp=[{"mlp_cls": "dense", "mlp_kwargs": {"activation": "silu", "gated": True}}],
+        mlp=[
+            {
+                "mlp_cls": "dense",
+                "mlp_kwargs": {
+                    "activation_cls": "swiglu",
+                },
+            }
+        ],
         norm_cls="rmsnorm",
         pos_emb_cls="rope",
         pos_emb_kwargs={"rope_theta": 1e4},
@@ -54,7 +61,7 @@ def _gpt2_cfg(impl):
         mlp=[
             {
                 "mlp_cls": "dense",
-                "mlp_kwargs": {"activation": "gelu", "gated": False, "bias": True},
+                "mlp_kwargs": {"activation_cls": "gelu", "bias": True},
             }
         ],
         norm_cls="layernorm",
@@ -76,7 +83,14 @@ def _qwen3_cfg(impl):
                 },
             }
         ],
-        mlp=[{"mlp_cls": "dense", "mlp_kwargs": {"activation": "silu", "gated": True}}],
+        mlp=[
+            {
+                "mlp_cls": "dense",
+                "mlp_kwargs": {
+                    "activation_cls": "swiglu",
+                },
+            }
+        ],
         norm_cls="rmsnorm",
         pos_emb_cls="rope",
         pos_emb_kwargs={"rope_theta": 1e4},
@@ -105,8 +119,7 @@ def _moe_cfg(impl):
                     "aux_loss": True,
                     "aux_loss_coef": 1e-3,
                     "n_routed_experts_per_token": 2,
-                    "activation": "silu",
-                    "gated": True,
+                    "activation_cls": "swiglu",
                 },
             }
         ],
@@ -242,8 +255,7 @@ def test_transformer_matches_hf_qwen3_with_copied_weights():
                 "mlp_cls": "dense",
                 "mlp_kwargs": {
                     "intermediate_size": intermediate_size,
-                    "activation": "silu",
-                    "gated": True,
+                    "activation_cls": "swiglu",
                 },
             }
         ],

--- a/tests/fast/quant/test_linear.py
+++ b/tests/fast/quant/test_linear.py
@@ -298,7 +298,9 @@ def test_quantized_linear_trains_a_full_model():
             mlp=[
                 {
                     "mlp_cls": "dense",
-                    "mlp_kwargs": {"activation": "silu", "gated": True},
+                    "mlp_kwargs": {
+                        "activation_cls": "swiglu",
+                    },
                 }
             ],
             norm_cls="rmsnorm",

--- a/tests/fast/quant/test_moe.py
+++ b/tests/fast/quant/test_moe.py
@@ -361,8 +361,7 @@ def test_quantized_sparse_moe_block_trains_a_full_model(bias):
                         "bias": bias,
                         "aux_loss": True,
                         "aux_loss_coef": 1e-3,
-                        "activation": "silu",
-                        "gated": True,
+                        "activation_cls": "swiglu",
                     },
                 }
             ],

--- a/tests/fast/training/test_optimizer.py
+++ b/tests/fast/training/test_optimizer.py
@@ -406,8 +406,7 @@ def _make_moe_cfg() -> TrainConfig:
                     "n_routed_experts_per_token": 2,
                     "n_shared_experts": 1,
                     "intermediate_size": 32,
-                    "activation": "silu",
-                    "gated": True,
+                    "activation_cls": "swiglu",
                 },
             }
         ],

--- a/tests/fast/training/test_trainer.py
+++ b/tests/fast/training/test_trainer.py
@@ -59,7 +59,10 @@ def _tiny_config(tmp_dir):
             mlp=[
                 {
                     "mlp_cls": "dense",
-                    "mlp_kwargs": {"activation": "gelu", "gated": False, "bias": True},
+                    "mlp_kwargs": {
+                        "activation_cls": "gelu",
+                        "bias": True,
+                    },
                 }
             ],
             norm_cls="layernorm",

--- a/tests/fast/utils/test_config.py
+++ b/tests/fast/utils/test_config.py
@@ -42,8 +42,7 @@ MINIMAL_CONFIG = {
             {
                 "mlp_cls": "dense",
                 "mlp_kwargs": {
-                    "activation": "silu",
-                    "gated": True,
+                    "activation_cls": "swiglu",
                     "intermediate_size": 0,
                 },
             }
@@ -91,9 +90,13 @@ def test_model_config_defaults():
     assert cfg.pos_emb_cls == "rope"
     assert cfg.residual_cls == "standard"
     # __post_init__ fills component defaults: attn_implementation for attn,
-    # intermediate_size (4*d_model) for mlp.
+    # intermediate_size (4*d_model) and the activation pair for mlp.
     assert cfg.resolve_attn(0)[1] == {"attn_implementation": "flex_attention"}
-    assert cfg.resolve_mlp(0)[1] == {"intermediate_size": 4 * 768}
+    assert cfg.resolve_mlp(0)[1] == {
+        "intermediate_size": 4 * 768,
+        "activation_cls": "swiglu",
+        "activation_kwargs": {},
+    }
     assert cfg.norm_kwargs == {}
     assert cfg.pos_emb_kwargs == {}
     assert cfg.residual_kwargs == {}
@@ -116,7 +119,7 @@ def test_load_config_model_kwargs():
         path = _write_yaml(tmp, MINIMAL_CONFIG)
         cfg = load_config(path)
         assert cfg.model.resolve_attn(0)[1]["n_heads"] == 4
-        assert cfg.model.resolve_mlp(0)[1]["activation"] == "silu"
+        assert cfg.model.resolve_mlp(0)[1]["activation_cls"] == "swiglu"
         assert cfg.model.pos_emb_kwargs["rope_theta"] == 1e4
 
 
@@ -668,82 +671,164 @@ def test_modelconfig_moe_unknown_router_score_fn_raises():
         )
 
 
-def test_modelconfig_unknown_activation_raises():
-    with pytest.raises(ValueError, match="Unknown activation"):
-        ModelConfig(mlp=[{"mlp_cls": "dense", "mlp_kwargs": {"activation": "mish"}}])
-
-
-def test_modelconfig_gated_only_activation_rejected_when_ungated():
-    # bilinear is gated-only; rejected for an ungated mlp
-    with pytest.raises(ValueError, match="Unknown activation"):
-        ModelConfig(
-            mlp=[
-                {
-                    "mlp_cls": "dense",
-                    "mlp_kwargs": {"activation": "bilinear", "gated": False},
-                }
-            ]
-        )
-    # accepted when gated
-    ModelConfig(
-        mlp=[
-            {
-                "mlp_cls": "dense",
-                "mlp_kwargs": {"activation": "bilinear", "gated": True},
-            }
-        ]
-    )
-
-
-ACT_LIMIT_ERRORS = [
-    # only an inverted numeric range is rejected; other shapes just skip
-    ({"up": {"min": 7, "max": 1}}, r"\['up'\] requires min < max"),
+ACT_KWARGS_ERRORS = [
+    # (activation_cls, activation_kwargs, expected message) -- an inverted bound is
+    # the only act_limit defect that raises; the rest are tolerated below
     (
-        {"up": {"min": 0, "max": -1}},
-        r"\['up'\] requires min < max",
-    ),  # 0 is a real bound
+        "swiglu",
+        {"act_limit": {"up": {"min": 7, "max": 1}}},
+        r"act_limit\['up'\] requires min < max",
+    ),
+    (
+        "swiglu",
+        {"act_limit": {"up": {"min": 0, "max": -1}}},  # 0 is a real bound
+        r"act_limit\['up'\] requires min < max",
+    ),
+    (
+        "silu",
+        {"act_limit": {"up": {"min": 7, "max": 1}}},
+        r"act_limit\['up'\] requires min < max",
+    ),
+]
+
+# (activation_cls, act_limit) shapes the check does not police -- kept verbatim and
+# left for the activation, which only reads its own 'gate'/'up' numeric bounds
+ACT_LIMITS_TOLERATED = [
+    ("swiglu", {"max": 7}),  # side keys that name no tensor
+    ("silu", {"gate": {"max": 7}}),  # gate limit on a unary activation
+    ("swiglu", {"gate": 7}),  # bounds that are not a dict
+    ("swiglu", {"gate": {}}),
+    ("swiglu", {"gate": {"lo": 1}}),  # bound keys that are not min/max
+    ("swiglu", {"up": {"min": "x"}}),  # non-numeric bound
+]
+
+ACT_LIMITS_OK = [
+    ({"gate": {"max": 7}}, "swiglu"),  # partial: only the gate's upper tail
+    ({"gate": {"max": 7}, "up": {"min": -7, "max": 7}}, "swiglu"),  # deepseek-v4
+    ({"up": {"min": -7}}, "swiglu"),
+    ({"up": {"max": 7}}, "silu"),  # unary clamps its single up tensor
+    ({"up": {"min": -7, "max": 7}}, "silu"),
 ]
 
 
+def test_modelconfig_activation_cls_raise_error():
+    with pytest.raises(ValueError, match="Unknown activation"):
+        ModelConfig(
+            mlp=[{"mlp_cls": "dense", "mlp_kwargs": {"activation_cls": "mish"}}]
+        )
+
+
+@pytest.mark.parametrize("activation_cls", ["swiglu", "silu", "bilinear", "powlu"])
+def test_modelconfig_activation_cls(activation_cls):
+    """The name alone resolves the activation; SwiGLU is the default."""
+    resolved = ModelConfig(d_model=64).resolve_mlp(0)[1]
+    assert resolved["activation_cls"] == "swiglu"
+    assert resolved["activation_kwargs"] == {}
+    cfg = ModelConfig(
+        d_model=64,
+        mlp=[{"mlp_cls": "dense", "mlp_kwargs": {"activation_cls": activation_cls}}],
+    )
+    assert cfg.resolve_mlp(0)[1]["activation_cls"] == activation_cls
+
+
 @pytest.mark.parametrize("mlp_cls", ["dense", "moe"])
-@pytest.mark.parametrize("limit,match", ACT_LIMIT_ERRORS)
-def test_modelconfig_activation_limit_raise_error(mlp_cls, limit, match):
-    kwargs = {"activation_limit": limit}
+@pytest.mark.parametrize("act_cls,act_kwargs,match", ACT_KWARGS_ERRORS)
+def test_modelconfig_activation_kwargs_raise_error(mlp_cls, act_cls, act_kwargs, match):
+    kwargs = {"activation_cls": act_cls, "activation_kwargs": act_kwargs}
     if mlp_cls == "moe":
         kwargs |= {"n_routed_experts": 4, "aux_loss": True}
     with pytest.raises(ValueError, match=match):
         ModelConfig(d_model=64, mlp=[{"mlp_cls": mlp_cls, "mlp_kwargs": kwargs}])
 
 
+@pytest.mark.parametrize("act_kwargs", [7.0, "off", None])
+def test_modelconfig_activation_kwargs_non_mapping_dropped(act_kwargs):
+    """A non-dict activation_kwargs is discarded, leaving the block's own default."""
+    cfg = ModelConfig(
+        d_model=64,
+        mlp=[{"mlp_cls": "dense", "mlp_kwargs": {"activation_kwargs": act_kwargs}}],
+    )
+    assert "activation_kwargs" not in cfg.resolve_mlp(0)[1]
+
+
+@pytest.mark.parametrize("act_cls,act_limit", ACT_LIMITS_TOLERATED)
+def test_modelconfig_activation_kwargs_act_limit_tolerated(act_cls, act_limit):
+    """Malformed-but-dict limits are stored verbatim rather than rejected."""
+    cfg = ModelConfig(
+        d_model=64,
+        mlp=[
+            {
+                "mlp_cls": "dense",
+                "mlp_kwargs": {
+                    "activation_cls": act_cls,
+                    "activation_kwargs": {"act_limit": act_limit},
+                },
+            }
+        ],
+    )
+    assert cfg.resolve_mlp(0)[1]["activation_kwargs"] == {"act_limit": act_limit}
+
+
+@pytest.mark.parametrize("act_limit", [7.0, "off"])
+def test_modelconfig_activation_kwargs_act_limit_non_dict_dropped(act_limit):
+    """A limit that is not a dict is discarded, leaving the activation unclamped."""
+    cfg = ModelConfig(
+        d_model=64,
+        mlp=[
+            {
+                "mlp_cls": "dense",
+                "mlp_kwargs": {"activation_kwargs": {"act_limit": act_limit}},
+            }
+        ],
+    )
+    assert cfg.resolve_mlp(0)[1]["activation_kwargs"] == {}
+
+
+@pytest.mark.parametrize("act_limit,activation_cls", ACT_LIMITS_OK)
+def test_modelconfig_activation_kwargs_act_limit(act_limit, activation_cls):
+    """Valid limits are stored verbatim; the shape follows the activation's arity."""
+    cfg = ModelConfig(
+        d_model=64,
+        mlp=[
+            {
+                "mlp_cls": "dense",
+                "mlp_kwargs": {
+                    "activation_cls": activation_cls,
+                    "activation_kwargs": {"act_limit": act_limit},
+                },
+            }
+        ],
+    )
+    assert cfg.resolve_mlp(0)[1]["activation_kwargs"] == {"act_limit": act_limit}
+
+
 @pytest.mark.parametrize(
-    "limit",
+    "act_kwargs",
     [
-        None,
-        {"gate": {"max": 7}},  # partial: only the gate's upper tail
-        {"gate": {"min": None, "max": 7}, "up": {"min": -7, "max": 7}},  # deepseek
-        {"gate": {"max": 7}, "note": "kept"},  # unrelated keys pass through unused
-        {"gate": 7, "up": {"max": 7}},  # non-mapping side skipped, stored verbatim
+        {"alpha": 1.702},
+        {"up_shift": 1.0},
+        # the gpt-oss SwiGLU, now expressible without a dedicated registry entry
+        {
+            "alpha": 1.702,
+            "up_shift": 1.0,
+            "act_limit": {"gate": {"max": 7.0}, "up": {"min": -7.0, "max": 7.0}},
+        },
     ],
 )
-def test_modelconfig_activation_limit(limit):
+def test_modelconfig_activation_kwargs(act_kwargs):
     cfg = ModelConfig(
         d_model=64,
-        mlp=[{"mlp_cls": "dense", "mlp_kwargs": {"activation_limit": limit}}],
+        mlp=[
+            {
+                "mlp_cls": "dense",
+                "mlp_kwargs": {
+                    "activation_cls": "swiglu",
+                    "activation_kwargs": act_kwargs,
+                },
+            }
+        ],
     )
-    # stored verbatim; the block reads missing sides/bounds as unbounded
-    assert cfg.resolve_mlp(0)[1]["activation_limit"] == limit
-    # left absent when unset, so the block's own default (unbounded) applies
-    assert "activation_limit" not in ModelConfig(d_model=64).resolve_mlp(0)[1]
-
-
-@pytest.mark.parametrize("limit", [7.0, "off", True])
-def test_modelconfig_activation_limit_non_mapping_disabled(limit):
-    # a non-mapping value is dropped rather than rejected: the limit is disabled
-    cfg = ModelConfig(
-        d_model=64,
-        mlp=[{"mlp_cls": "dense", "mlp_kwargs": {"activation_limit": limit}}],
-    )
-    assert "activation_limit" not in cfg.resolve_mlp(0)[1]
+    assert cfg.resolve_mlp(0)[1]["activation_kwargs"] == act_kwargs
 
 
 def test_modelconfig_validates_attn_dims():


### PR DESCRIPTION
## Summary

Collapses the `GATED_ACTIVATIONS` / `UNGATED_ACTIVATIONS` split into one `ACT_REGISTRY` whose entries carry their own arity, so an activation's name alone picks gated vs unary and the separate `gated` MLP key is no longer needed.

## Changes

- **One registry.** `ACT_REGISTRY: dict[str, Activation(fn, gated)]` in `src/layers/activation.py`. `DenseMLPBlock` / `SparseMoEBlock` derive `gated` from the entry instead of taking it as a kwarg.
- **General activation kwargs.** MLP kwargs are `activation_cls` + `activation_kwargs`; the old `activation_limit` key folds into `activation_kwargs["act_limit"]`, alongside `alpha`, `up_shift`, `negative_slope`, `m`.
- **Clamping moved into the activations.** `mlp.py` no longer clamps; each activation applies its own `act_limit`, keyed `gate`/`up`.
- **`silu_openai` / `silu_openai_glu` deleted.** The gpt-oss form is now expressible as `silu`/`swiglu` with `alpha=1.702`, `up_shift=1.0` and an `act_limit`, so it needs no dedicated registry entry.
- **FLOPs/params simplified.** `compute_flops` / `compute_parameters` collapse their gated/ungated branches to a single `n_in` multiplier (2 gated, 1 unary).
- **Config validation relaxed.** `_set_default_mlp_kwargs` validates the activation name and `min < max`; malformed `activation_kwargs` / `act_limit` values are dropped rather than raising.
- **38 YAML configs migrated** to the new keys.

## Testing

`uv run pytest tests/fast -n 6` — 22313 passed, 5382 skipped (run before the final two config-validation edits; `tests/fast/layers` + `tests/fast/utils/test_config.py` re-run green after). Ruff check and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)